### PR TITLE
Marketing and Programs in Devstack

### DIFF
--- a/docker-compose-host.yml
+++ b/docker-compose-host.yml
@@ -33,7 +33,13 @@ services:
   forum:
     volumes:
       - ${DEVSTACK_WORKSPACE}/cs_comments_service:/edx/app/forum/cs_comments_service:cached
-      
+  edraak_programs:
+    volumes:
+      - ${DEVSTACK_WORKSPACE}/edraak-programs:/app:cached
+  edraak_marketing:
+    volumes:
+      - ${DEVSTACK_WORKSPACE}/marketing-site:/app:cached
+
 volumes:
   credentials_node_modules:
   discovery_node_modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -217,6 +217,34 @@ services:
     volumes:
       - devpi_data:/data
 
+  edraak_programs:
+    image: edraak-devstack-programs
+    environment:
+      PROGS_CFG: '/app/docker.json'
+      NODE_ENV: development
+    command: bash -c 'while true; do python manage.py runserver 0.0.0.0:8800 --settings=edraakprograms.dev; sleep 2; done'
+    container_name: edraak.devstack.programs
+    working_dir: /app
+    ports:
+      - "18901:8800"
+    depends_on:
+      - mysql
+      - mongo
+      - memcached
+
+  edraak_marketing:
+    image: edraak-devstack-marketing
+    environment:
+      NODE_ENV: development
+    command: bash -c 'while true; do python manage.py runserver 0.0.0.0:8800 --settings=marketingsite.envs.dev; sleep 2; done'
+    container_name: edraak.devstack.marketing
+    working_dir: /app
+    ports:
+      - "18902:8800"
+    depends_on:
+      - mysql
+      - memcached
+
 volumes:
   discovery_assets:
   edxapp_lms_assets:

--- a/edraak.mk
+++ b/edraak.mk
@@ -1,0 +1,73 @@
+edraak.provision:
+	DOCKER_COMPOSE_FILES="-f docker-compose.yml -f docker-compose-host.yml" ./provision-edraak.sh
+
+provision.edraak:
+	$(MAKE) edraak.provision
+
+edraak.build.all:
+	$(MAKE) edraak.build.programs
+	$(MAKE) edraak.build.marketing
+
+edraak.build.programs:
+	docker build -t edraak-devstack-programs -f ../edraak-programs/Dockerfile ../edraak-programs
+
+edraak.build.marketing:
+	docker build -t edraak-devstack-marketing -f ../marketing-site/Dockerfile ../marketing-site
+
+edraak.programs.help:
+	echo ""
+	echo "make edraak.programs.COMMAND"
+	echo "======================================"
+	echo ""
+	echo "Commands:"
+	echo ""
+	echo "migrate:              Run django migrations i.e. python manage.py migrate"
+	echo "compile_static:       Run python manage.py compilestatic --settings=edraakprograms.static"
+	echo "install_pip:          Install python dependencies in 'requirements.txt' file"
+	echo "install_npm:          Install npm dependencies in 'package.json' file"
+	echo "gulp:                 Run gulp command"
+	echo "install_all:          Runs install_pip, install_npm, migrate, compilestatic"
+	echo "watch_js:             Run watcher to watch JavaScript changes"
+	echo "watch_css:            Run watcher to watch and compile scss changes"
+	echo "manage:               Run any manage.py command"
+	echo "shell:                Open bash inside docker container"
+	echo "copy_cache:           Copy node_modules, installed at build time, to the current app"
+	echo "help:                 Print help and exit"
+	echo ""
+
+edraak.programs.migrate:
+	docker-compose exec edraak_programs python manage.py migrate --settings=edraakprograms.dev
+
+edraak.programs.compile_static:
+	docker-compose exec edraak_programs python manage.py compilestatic --settings=edraakprograms.static
+
+edraak.programs.install_pip:
+	docker-compose exec edraak_programs pip install -r requirements.txt
+
+edraak.programs.install_npm:
+	docker-compose exec edraak_programs npm install
+
+edraak.programs.copy_cache:
+	docker-compose exec edraak_programs cp -Rnv /cache/node_modules /cache/.compiled /app
+
+edraak.programs.gulp:
+	docker-compose exec edraak_programs gulp
+
+edraak.programs.install_all:
+	$(MAKE) edraak.programs.copy_cache
+	$(MAKE) edraak.programs.gulp
+	$(MAKE) edraak.programs.migrate
+	$(MAKE) edraak.programs.compilestatic
+
+edraak.programs.watch_js:
+	docker-compose exec edraak_programs gulp watch
+
+edraak.programs.watch_css:
+	docker-compose exec edraak_programs npm run watch-scss
+
+edraak.programs.shell:
+	docker-compose exec edraak_programs bash
+
+edraak.marketing.shell:
+	docker-compose exec edraak_marketing bash
+

--- a/provision-edraak.sh
+++ b/provision-edraak.sh
@@ -1,0 +1,28 @@
+set -e
+
+echo "** Bringing up **"
+docker-compose $DOCKER_COMPOSE_FILES up -d mysql edraak_programs edraak_marketing
+
+echo "** Creating databases **"
+docker exec -i edx.devstack.mysql mysql -uroot mysql < provision-edraak.sql
+
+echo "** Restarting **"
+docker-compose restart edraak_programs
+docker-compose restart edraak_marketing
+
+echo "** Migrating databases **"
+docker-compose exec edraak_programs bash -c 'python manage.py migrate --settings=edraakprograms.dev'
+docker-compose exec edraak_marketing bash -c 'python manage.py migrate --settings=marketingsite.envs.dev'
+
+echo "** Compiling assets **"
+docker-compose exec edraak_programs bash -c 'cp -Rnv /cache/node_modules /cache/.compiled /app'
+docker-compose exec edraak_programs bash -c 'npm rebuild node-sass'
+docker-compose exec edraak_programs bash -c 'gulp'
+docker-compose exec edraak_programs bash -c 'python manage.py compilestatic --settings=edraakprograms.static'
+docker-compose exec edraak_programs bash -c 'python manage.py collectstatic --ignore="*.less" --ignore="*.scss" --noinput --clear --settings=edraakprograms.dev'
+docker-compose exec edraak_marketing bash -c 'yarn'
+docker-compose exec edraak_marketing bash -c 'npx gulp'
+
+echo "** Restarting **"
+docker-compose restart edraak_programs
+docker-compose restart edraak_marketing

--- a/provision-edraak.sql
+++ b/provision-edraak.sql
@@ -1,0 +1,2 @@
+CREATE DATABASE IF NOT EXISTS edraakprograms;
+CREATE DATABASE IF NOT EXISTS marketingsite;

--- a/provision.sh
+++ b/provision.sh
@@ -48,6 +48,7 @@ docker-compose $DOCKER_COMPOSE_FILES up -d studio
 ./provision-e2e.sh
 ./provision-forum.sh
 ./provision-notes.sh
+./provision-edraak.sh
 
 docker image prune -f
 


### PR DESCRIPTION
This is to add `edraak-programs` and `marketing-site` to `devstack` to have everything manged from the same environment

Three steps to have `edraak-programs` and `marketing-site` ready in devstack:

**Step1**: clone both repose inside `devstack workspace directory`

**Step2**: build docker images:
```
make edraak.build.all
```

**Step3**: provision:
```
make edraak.provision
```

------------
Related PRs:
https://github.com/Edraak/edraak-programs/pull/1013
https://github.com/Edraak/marketing-site/pull/370
