### PR TITLE
Devstack Provision and Clone for Marketing and Programs

### DIFF
--- a/edraak.mk
+++ b/edraak.mk
@@ -62,6 +62,9 @@ edraak.programs.install_all:
 edraak.programs.watch_js:
 	docker-compose exec edraak_programs gulp watch
 
+edraak.programs.provision:
+	DOCKER_COMPOSE_FILES="-f docker-compose.yml -f docker-compose-host.yml" ./provision-edraak-programs.sh
+
 edraak.programs.watch_css:
 	docker-compose exec edraak_programs npm run watch-scss
 
@@ -71,3 +74,5 @@ edraak.programs.shell:
 edraak.marketing.shell:
 	docker-compose exec edraak_marketing bash
 
+edraak.marketing.provision:
+	DOCKER_COMPOSE_FILES="-f docker-compose.yml -f docker-compose-host.yml" ./provision-edraak-marketing.sh

--- a/provision-edraak-marketing.sh
+++ b/provision-edraak-marketing.sh
@@ -1,0 +1,14 @@
+set -e
+
+echo "** Restarting **"
+docker-compose restart edraak_marketing
+
+echo "** Migrating databases **"
+docker-compose exec edraak_marketing bash -c 'python manage.py migrate --settings=marketingsite.envs.dev'
+
+echo "** Compiling assets **"
+docker-compose exec edraak_marketing bash -c 'yarn'
+docker-compose exec edraak_marketing bash -c 'npx gulp'
+
+echo "** Restarting **"
+docker-compose restart edraak_marketing

--- a/provision-edraak-programs.sh
+++ b/provision-edraak-programs.sh
@@ -1,0 +1,17 @@
+set -e
+
+echo "** Restarting **"
+docker-compose restart edraak_programs
+
+echo "** Migrating databases **"
+docker-compose exec edraak_programs bash -c 'python manage.py migrate --settings=edraakprograms.dev'
+
+echo "** Compiling assets **"
+docker-compose exec edraak_programs bash -c 'cp -Rnv /cache/node_modules /cache/.compiled /app'
+docker-compose exec edraak_programs bash -c 'npm rebuild node-sass'
+docker-compose exec edraak_programs bash -c 'gulp'
+docker-compose exec edraak_programs bash -c 'python manage.py compilestatic --settings=edraakprograms.static'
+docker-compose exec edraak_programs bash -c 'python manage.py collectstatic --ignore="*.less" --ignore="*.scss" --noinput --clear --settings=edraakprograms.dev'
+
+echo "** Restarting **"
+docker-compose restart edraak_programs

--- a/provision-edraak.sh
+++ b/provision-edraak.sh
@@ -6,23 +6,8 @@ docker-compose $DOCKER_COMPOSE_FILES up -d mysql edraak_programs edraak_marketin
 echo "** Creating databases **"
 docker exec -i edx.devstack.mysql mysql -uroot mysql < provision-edraak.sql
 
-echo "** Restarting **"
-docker-compose restart edraak_programs
-docker-compose restart edraak_marketing
+echo "** Marketing **"
+./provision-edraak-marketing.sh
 
-echo "** Migrating databases **"
-docker-compose exec edraak_programs bash -c 'python manage.py migrate --settings=edraakprograms.dev'
-docker-compose exec edraak_marketing bash -c 'python manage.py migrate --settings=marketingsite.envs.dev'
-
-echo "** Compiling assets **"
-docker-compose exec edraak_programs bash -c 'cp -Rnv /cache/node_modules /cache/.compiled /app'
-docker-compose exec edraak_programs bash -c 'npm rebuild node-sass'
-docker-compose exec edraak_programs bash -c 'gulp'
-docker-compose exec edraak_programs bash -c 'python manage.py compilestatic --settings=edraakprograms.static'
-docker-compose exec edraak_programs bash -c 'python manage.py collectstatic --ignore="*.less" --ignore="*.scss" --noinput --clear --settings=edraakprograms.dev'
-docker-compose exec edraak_marketing bash -c 'yarn'
-docker-compose exec edraak_marketing bash -c 'npx gulp'
-
-echo "** Restarting **"
-docker-compose restart edraak_programs
-docker-compose restart edraak_marketing
+echo "** Programs **"
+./provision-edraak-programs.sh

--- a/repo.sh
+++ b/repo.sh
@@ -27,6 +27,8 @@ repos=(
     "https://github.com/Edraak/edraak-platform.git"
     "https://github.com/Edraak/xqueue.git"
     "https://github.com/Edraak/edx-analytics-pipeline.git"
+    "git@github.com:Edraak/marketing-site.git"
+    "git@github.com:Edraak/edraak-programs.git"
 )
 
 repo_alternative_directory=(


### PR DESCRIPTION
- Adding two commands in Makefile:

`make edraak.programs.provision`
and
`make edraak.marketing.provision`

This will make it easy to recollect assets for marketing when some javascript is changed

- Adding `marketing-site` and `edraak-programs` repositories in clone process accessed by calling `make dev.clone`