### PR TITLE
Hack: Drop nginx cookies to ensure only `.edraak.dev` cookies are kept

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -11,7 +11,7 @@ server {
     include /etc/nginx/conf.d/includes/server.conf;
 
     location / {
-        return 301 http://www.edraak.dev$request_uri;
+        return 301 https://www.edraak.dev$request_uri;
     }
 }
 

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -7,7 +7,16 @@ server {
 }
 
 server {
-    server_name edraak.dev www.edraak.dev;
+    server_name edraak.dev;
+    include /etc/nginx/conf.d/includes/server.conf;
+
+    location / {
+        return 301 http://www.edraak.dev$request_uri;
+    }
+}
+
+server {
+    server_name www.edraak.dev;
     include /etc/nginx/conf.d/includes/server.conf;
 
     location / {

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -7,70 +7,41 @@ server {
 }
 
 server {
-    listen              443 ssl;
-    ssl_certificate     conf.d/ssl/certificate.crt;
-    ssl_certificate_key conf.d/ssl/private.key;
-    ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
-
-    server_name www.edraak.dev edraak.dev;
-    client_max_body_size 100M;
+    server_name edraak.dev www.edraak.dev;
+    include /etc/nginx/conf.d/includes/server.conf;
 
     location / {
         proxy_pass http://edraak.devstack.marketing:8500;
-        proxy_connect_timeout   100m;
-        proxy_send_timeout      100m;
-        proxy_read_timeout      100m;
+        include /etc/nginx/conf.d/includes/proxy.conf;
     }
 }
 
 server {
-    listen              443 ssl;
-    ssl_certificate     conf.d/ssl/certificate.crt;
-    ssl_certificate_key conf.d/ssl/private.key;
-    ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
-
     server_name programs.edraak.dev;
-    client_max_body_size 100M;
+    include /etc/nginx/conf.d/includes/server.conf;
 
     location / {
         proxy_pass http://edraak.devstack.programs:8800;
-        proxy_connect_timeout   100m;
-        proxy_send_timeout      100m;
-        proxy_read_timeout      100m;
-
+        include /etc/nginx/conf.d/includes/proxy.conf;
     }
 }
 
 server {
-    listen              443 ssl;
-    ssl_certificate     conf.d/ssl/certificate.crt;
-    ssl_certificate_key conf.d/ssl/private.key;
-    ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
-
     server_name courses.edraak.dev;
-    client_max_body_size 100M;
+    include /etc/nginx/conf.d/includes/server.conf;
 
     location / {
         proxy_pass http://edx.devstack.lms:18000;
-        proxy_connect_timeout   100m;
-        proxy_send_timeout      100m;
-        proxy_read_timeout      100m;
+        include /etc/nginx/conf.d/includes/proxy.conf;
     }
 }
 
 server {
-    listen              443 ssl;
-    ssl_certificate     conf.d/ssl/certificate.crt;
-    ssl_certificate_key conf.d/ssl/private.key;
-    ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
-
     server_name studio.edraak.dev;
-    client_max_body_size 100M;
+    include /etc/nginx/conf.d/includes/server.conf;
 
     location / {
         proxy_pass http://edx.devstack.studio:18010;
-        proxy_connect_timeout   100m;
-        proxy_send_timeout      100m;
-        proxy_read_timeout      100m;
+        include /etc/nginx/conf.d/includes/proxy.conf;
     }
 }

--- a/nginx/includes/proxy.conf
+++ b/nginx/includes/proxy.conf
@@ -1,0 +1,7 @@
+proxy_connect_timeout   100m;
+proxy_send_timeout      100m;
+proxy_read_timeout      100m;
+
+add_header Set-Cookie "csrftoken=deleted; expires=Thu, 01 Jan 1970 00:00:01 GMT; path=/;";
+add_header Set-Cookie "sessionid=deleted; expires=Thu, 01 Jan 1970 00:00:01 GMT; path=/;";
+add_header Set-Cookie "openedx-language-preference=deleted; expires=Thu, 01 Jan 1970 00:00:01 GMT; path=/;";

--- a/nginx/includes/server.conf
+++ b/nginx/includes/server.conf
@@ -1,0 +1,5 @@
+listen              443 ssl;
+ssl_certificate     conf.d/ssl/certificate.crt;
+ssl_certificate_key conf.d/ssl/private.key;
+ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
+client_max_body_size 100M;


### PR DESCRIPTION
This is the only way I was able to remove the erroneous `courses.edraak.dev` cookies.