### PR TITLE
Rename devstack volumes to ensure no data clash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ DEVSTACK_WORKSPACE ?= $(shell pwd)/..
 
 OS := $(shell uname)
 
-COMPOSE_PROJECT_NAME=devstack
+COMPOSE_PROJECT_NAME=edraak_devstack
 
 export DEVSTACK_WORKSPACE
 export COMPOSE_PROJECT_NAME


### PR DESCRIPTION
Docker is stupid I have clash on my computer between different devstacks e.g. upstream Juniper and Edraak Hawthorn.

:warning: This will break existing volumes and will require another `$ make dev.provision`