### PR TITLE
Allow passing env var for config json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,10 +63,10 @@ dev.repo.reset: ## Attempts to reset the local repo checkouts to the master work
 
 dev.editable-envs:  ## Copy env files outside the docker containers so it's editable by the developer
 	mkdir -p $(DEVSTACK_WORKSPACE)/src/edxapp-envs/
-	@docker exec -it edx.devstack.lms bash -c 'test -f /edx/src/edxapp-envs/lms.env.json || mv /edx/app/edxapp/lms.{env,auth}.json /edx/src/edxapp-envs/'
-	@docker exec -it edx.devstack.lms bash -c 'ln -sf /edx/src/edxapp-envs/lms.{env,auth}.json /edx/app/edxapp/'
-	@docker exec -it edx.devstack.studio bash -c 'test -f /edx/src/edxapp-envs/cms.env.json || mv /edx/app/edxapp/cms.{env,auth}.json /edx/src/edxapp-envs/'
-	@docker exec -it edx.devstack.studio bash -c 'ln -sf /edx/src/edxapp-envs/cms.{env,auth}.json /edx/app/edxapp/'
+	@docker exec -it b2b.devstack.lms bash -c 'test -f /edx/src/edxapp-envs/lms.env.json || mv /edx/app/edxapp/lms.{env,auth}.json /edx/src/edxapp-envs/'
+	@docker exec -it b2b.devstack.lms bash -c 'ln -sf /edx/src/edxapp-envs/lms.{env,auth}.json /edx/app/edxapp/'
+	@docker exec -it b2b.devstack.studio bash -c 'test -f /edx/src/edxapp-envs/cms.env.json || mv /edx/app/edxapp/cms.{env,auth}.json /edx/src/edxapp-envs/'
+	@docker exec -it b2b.devstack.studio bash -c 'ln -sf /edx/src/edxapp-envs/cms.{env,auth}.json /edx/app/edxapp/'
 	@sudo chown -R $(USER) $(DEVSTACK_WORKSPACE)/src
 	@make lms-restart
 	@make studio-restart
@@ -116,9 +116,9 @@ edraak.dev.up.hacks:
 	@# TODO: Add this to `base.in` (thus `development.txt`) and rebuild the docker image
 	@make dev.editable-envs
 	@for container in lms studio lms_watcher studio_watcher; do \
-		 docker exec -it edx.devstack.$$container bash -c 'source /edx/app/edxapp/edxapp_env && pip install python-bidi==0.4.0'; \
-		 docker exec -it edx.devstack.$$container bash -c 'source /edx/app/edxapp/edxapp_env && pip install wand==0.5.1'; \
-		 docker exec -it edx.devstack.$$container bash -c 'source /edx/app/edxapp/edxapp_env && pip install -e /edx/app/edxapp/edx-platform'; \
+		 docker exec -it b2b.devstack.$$container bash -c 'source /edx/app/edxapp/edxapp_env && pip install python-bidi==0.4.0'; \
+		 docker exec -it b2b.devstack.$$container bash -c 'source /edx/app/edxapp/edxapp_env && pip install wand==0.5.1'; \
+		 docker exec -it b2b.devstack.$$container bash -c 'source /edx/app/edxapp/edxapp_env && pip install -e /edx/app/edxapp/edx-platform'; \
     done;
 	@make lms-restart
 	@make studio-restart
@@ -168,14 +168,14 @@ validate: ## Validate the devstack configuration
 	docker-compose config
 
 backup: ## Write all data volumes to the host.
-	docker run --rm --volumes-from edx.devstack.mysql -v $$(pwd)/.dev/backups:/backup debian:jessie tar zcvf /backup/mysql.tar.gz /var/lib/mysql
-	docker run --rm --volumes-from edx.devstack.mongo -v $$(pwd)/.dev/backups:/backup debian:jessie tar zcvf /backup/mongo.tar.gz /data/db
-	docker run --rm --volumes-from edx.devstack.elasticsearch -v $$(pwd)/.dev/backups:/backup debian:jessie tar zcvf /backup/elasticsearch.tar.gz /usr/share/elasticsearch/data
+	docker run --rm --volumes-from b2b.devstack.mysql -v $$(pwd)/.dev/backups:/backup debian:jessie tar zcvf /backup/mysql.tar.gz /var/lib/mysql
+	docker run --rm --volumes-from b2b.devstack.mongo -v $$(pwd)/.dev/backups:/backup debian:jessie tar zcvf /backup/mongo.tar.gz /data/db
+	docker run --rm --volumes-from b2b.devstack.elasticsearch -v $$(pwd)/.dev/backups:/backup debian:jessie tar zcvf /backup/elasticsearch.tar.gz /usr/share/elasticsearch/data
 
 restore:  ## Restore all data volumes from the host. WARNING: THIS WILL OVERWRITE ALL EXISTING DATA!
-	docker run --rm --volumes-from edx.devstack.mysql -v $$(pwd)/.dev/backups:/backup debian:jessie tar zxvf /backup/mysql.tar.gz
-	docker run --rm --volumes-from edx.devstack.mongo -v $$(pwd)/.dev/backups:/backup debian:jessie tar zxvf /backup/mongo.tar.gz
-	docker run --rm --volumes-from edx.devstack.elasticsearch -v $$(pwd)/.dev/backups:/backup debian:jessie tar zxvf /backup/elasticsearch.tar.gz
+	docker run --rm --volumes-from b2b.devstack.mysql -v $$(pwd)/.dev/backups:/backup debian:jessie tar zxvf /backup/mysql.tar.gz
+	docker run --rm --volumes-from b2b.devstack.mongo -v $$(pwd)/.dev/backups:/backup debian:jessie tar zxvf /backup/mongo.tar.gz
+	docker run --rm --volumes-from b2b.devstack.elasticsearch -v $$(pwd)/.dev/backups:/backup debian:jessie tar zxvf /backup/elasticsearch.tar.gz
 
 %-edbash: ## Run a shell on the specified service container
 	docker exec -it edraak.devstack.$* /bin/bash
@@ -184,73 +184,73 @@ restore:  ## Restore all data volumes from the host. WARNING: THIS WILL OVERWRIT
 # TODO: Print out help for this target. Even better if we can iterate over the
 # services in docker-compose.yml, and print the actual service names.
 %-shell: ## Run a shell on the specified service container
-	docker exec -it edx.devstack.$* /bin/bash
+	docker exec -it b2b.devstack.$* /bin/bash
 
 
 credentials-shell:
-	docker exec -it edx.devstack.credentials env TERM=$(TERM) bash -c 'source /edx/app/credentials/credentials_env && cd /edx/app/credentials/credentials && /bin/bash'
+	docker exec -it b2b.devstack.credentials env TERM=$(TERM) bash -c 'source /edx/app/credentials/credentials_env && cd /edx/app/credentials/credentials && /bin/bash'
 
 discovery-shell: ## Run a shell on the discovery container
-	docker exec -it edx.devstack.discovery env TERM=$(TERM) /edx/app/discovery/devstack.sh open
+	docker exec -it b2b.devstack.discovery env TERM=$(TERM) /edx/app/discovery/devstack.sh open
 
 ecommerce-shell: ## Run a shell on the ecommerce container
-	docker exec -it edx.devstack.ecommerce env TERM=$(TERM) /edx/app/ecommerce/devstack.sh open
+	docker exec -it b2b.devstack.ecommerce env TERM=$(TERM) /edx/app/ecommerce/devstack.sh open
 
 e2e-shell: ## Start the end-to-end tests container with a shell
 	docker run -it --network=devstack_default -v ${DEVSTACK_WORKSPACE}/edx-e2e-tests:/edx-e2e-tests -v ${DEVSTACK_WORKSPACE}/edx-platform:/edx-e2e-tests/lib/edx-platform --env-file ${DEVSTACK_WORKSPACE}/edx-e2e-tests/devstack_env edxops/e2e env TERM=$(TERM) bash
 
 %-update-db: ## Run migrations for the specified service container
-	docker exec -t edx.devstack.$* bash -c 'source /edx/app/$*/$*_env && cd /edx/app/$*/$*/ && make migrate'
+	docker exec -t b2b.devstack.$* bash -c 'source /edx/app/$*/$*_env && cd /edx/app/$*/$*/ && make migrate'
 
 studio-update-db: ## Run migrations for the Studio container
-	docker exec -t edx.devstack.studio bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform/ && paver update_db'
+	docker exec -t b2b.devstack.studio bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform/ && paver update_db'
 
 lms-update-db: ## Run migrations LMS container
-	docker exec -t edx.devstack.lms bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform/ && paver update_db'
+	docker exec -t b2b.devstack.lms bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform/ && paver update_db'
 
 update-db: | studio-update-db lms-update-db discovery-update-db ecommerce-update-db credentials-update-db ## Run the migrations for all services
 
 lms-shell: ## Run a shell on the LMS container
-	docker exec -it edx.devstack.lms env TERM=$(TERM) /edx/app/edxapp/devstack.sh open
+	docker exec -it b2b.devstack.lms env TERM=$(TERM) /edx/app/edxapp/devstack.sh open
 
 lms-watcher-shell: ## Run a shell on the LMS watcher container
-	docker exec -it edx.devstack.lms_watcher env TERM=$(TERM) /edx/app/edxapp/devstack.sh open
+	docker exec -it b2b.devstack.lms_watcher env TERM=$(TERM) /edx/app/edxapp/devstack.sh open
 
 %-attach: ## Attach to the specified service container process to use the debugger & see logs.
-	docker attach edx.devstack.$*
+	docker attach b2b.devstack.$*
 
 lms-restart: ## Kill the LMS Django development server. The watcher process will restart it.
-	docker exec -t edx.devstack.lms bash -c 'kill $$(ps aux | grep "manage.py lms" | egrep -v "while|grep" | awk "{print \$$2}")'
+	docker exec -t b2b.devstack.lms bash -c 'kill $$(ps aux | grep "manage.py lms" | egrep -v "while|grep" | awk "{print \$$2}")'
 
 studio-shell: ## Run a shell on the Studio container
-	docker exec -it edx.devstack.studio env TERM=$(TERM) /edx/app/edxapp/devstack.sh open
+	docker exec -it b2b.devstack.studio env TERM=$(TERM) /edx/app/edxapp/devstack.sh open
 
 studio-watcher-shell: ## Run a shell on the studio watcher container
-	docker exec -it edx.devstack.studio_watcher env TERM=$(TERM) /edx/app/edxapp/devstack.sh open
+	docker exec -it b2b.devstack.studio_watcher env TERM=$(TERM) /edx/app/edxapp/devstack.sh open
 
 studio-restart: ## Kill the LMS Django development server. The watcher process will restart it.
-	docker exec -t edx.devstack.studio bash -c 'kill $$(ps aux | grep "manage.py cms" | egrep -v "while|grep" | awk "{print \$$2}")'
+	docker exec -t b2b.devstack.studio bash -c 'kill $$(ps aux | grep "manage.py cms" | egrep -v "while|grep" | awk "{print \$$2}")'
 
 xqueue-shell: ## Run a shell on the XQueue container
-	docker exec -it edx.devstack.xqueue env TERM=$(TERM) /edx/app/xqueue/devstack.sh open
+	docker exec -it b2b.devstack.xqueue env TERM=$(TERM) /edx/app/xqueue/devstack.sh open
 
 xqueue-restart: ## Kill the XQueue development server. The watcher process will restart it.
-	docker exec -t edx.devstack.xqueue bash -c 'kill $$(ps aux | grep "manage.py runserver" | egrep -v "while|grep" | awk "{print \$$2}")'
+	docker exec -t b2b.devstack.xqueue bash -c 'kill $$(ps aux | grep "manage.py runserver" | egrep -v "while|grep" | awk "{print \$$2}")'
 
 xqueue_consumer-shell: ## Run a shell on the XQueue consumer container
-	docker exec -it edx.devstack.xqueue_consumer env TERM=$(TERM) /edx/app/xqueue/devstack.sh open
+	docker exec -it b2b.devstack.xqueue_consumer env TERM=$(TERM) /edx/app/xqueue/devstack.sh open
 
 xqueue_consumer-restart: ## Kill the XQueue development server. The watcher process will restart it.
-	docker exec -t edx.devstack.xqueue_consumer bash -c 'kill $$(ps aux | grep "manage.py run_consumer" | egrep -v "while|grep" | awk "{print \$$2}")'
+	docker exec -t b2b.devstack.xqueue_consumer bash -c 'kill $$(ps aux | grep "manage.py run_consumer" | egrep -v "while|grep" | awk "{print \$$2}")'
 
 %-static: ## Rebuild static assets for the specified service container
-	docker exec -t edx.devstack.$* bash -c 'source /edx/app/$*/$*_env && cd /edx/app/$*/$*/ && make static'
+	docker exec -t b2b.devstack.$* bash -c 'source /edx/app/$*/$*_env && cd /edx/app/$*/$*/ && make static'
 
 lms-static: ## Rebuild static assets for the LMS container
-	docker exec -t edx.devstack.lms bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform/ && paver update_assets'
+	docker exec -t b2b.devstack.lms bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform/ && paver update_assets'
 
 studio-static: ## Rebuild static assets for the Studio container
-	docker exec -t edx.devstack.studio bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform/ && paver update_assets'
+	docker exec -t b2b.devstack.studio bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform/ && paver update_assets'
 
 static: | credentials-static discovery-static ecommerce-static lms-static studio-static ## Rebuild static assets for all service containers
 
@@ -262,12 +262,12 @@ e2e-tests: ## Run the end-to-end tests against the service containers
 
 validate-lms-volume: ## Validate that changes to the local workspace are reflected in the LMS container
 	touch $(DEVSTACK_WORKSPACE)/edx-platform/testfile
-	docker exec edx.devstack.lms ls /edx/app/edxapp/edx-platform/testfile
+	docker exec b2b.devstack.lms ls /edx/app/edxapp/edx-platform/testfile
 	rm $(DEVSTACK_WORKSPACE)/edx-platform/testfile
 
 vnc-passwords: ## Get the VNC passwords for the Chrome and Firefox Selenium containers
-	@docker logs edx.devstack.chrome 2>&1 | grep "VNC password" | tail -1
-	@docker logs edx.devstack.firefox 2>&1 | grep "VNC password" | tail -1
+	@docker logs b2b.devstack.chrome 2>&1 | grep "VNC password" | tail -1
+	@docker logs b2b.devstack.firefox 2>&1 | grep "VNC password" | tail -1
 
 devpi-password: ## Get the root devpi password for the devpi container
 	docker-compose exec devpi bash -c "cat /data/server/.serverpassword"
@@ -289,7 +289,7 @@ dev.provision.analytics_pipeline.run:
 	DOCKER_COMPOSE_FILES="-f docker-compose.yml -f docker-compose-host.yml -f docker-compose-analytics-pipeline.yml" ./provision-analytics-pipeline.sh
 
 analytics-pipeline-shell: ## Run a shell on the analytics pipeline container
-	docker exec -it edx.devstack.analytics_pipeline env TERM=$(TERM) /edx/app/analytics_pipeline/devstack.sh open
+	docker exec -it b2b.devstack.analytics_pipeline env TERM=$(TERM) /edx/app/analytics_pipeline/devstack.sh open
 
 dev.up.analytics_pipeline: | check-memory ## Bring up analytics pipeline services
 	docker-compose -f docker-compose.yml -f docker-compose-analytics-pipeline.yml -f docker-compose-host.yml up -d analyticspipeline
@@ -298,14 +298,14 @@ pull.analytics_pipeline: ## Update analytics pipeline docker images
 	docker-compose -f docker-compose.yml -f docker-compose-analytics-pipeline.yml pull --parallel
 
 analytics-pipeline-devstack-test: ## Run analytics pipeline tests in travis build
-	docker exec -u hadoop -i edx.devstack.analytics_pipeline bash -c 'sudo chown -R hadoop:hadoop /edx/app/analytics_pipeline && source /edx/app/hadoop/.bashrc && make develop-local && make docker-test-acceptance-local ONLY_TESTS=edx.analytics.tasks.tests.acceptance.test_internal_reporting_database && make docker-test-acceptance-local ONLY_TESTS=edx.analytics.tasks.tests.acceptance.test_user_activity'
+	docker exec -u hadoop -i b2b.devstack.analytics_pipeline bash -c 'sudo chown -R hadoop:hadoop /edx/app/analytics_pipeline && source /edx/app/hadoop/.bashrc && make develop-local && make docker-test-acceptance-local ONLY_TESTS=edx.analytics.tasks.tests.acceptance.test_internal_reporting_database && make docker-test-acceptance-local ONLY_TESTS=edx.analytics.tasks.tests.acceptance.test_user_activity'
 
 stop.analytics_pipeline: ## Stop analytics pipeline services
 	docker-compose -f docker-compose.yml -f docker-compose-analytics-pipeline.yml stop
 	docker-compose up -d mysql      ## restart mysql as other containers need it
 
 hadoop-application-logs-%: ## View hadoop logs by application Id
-	docker exec -it edx.devstack.analytics_pipeline.nodemanager yarn logs -applicationId $*
+	docker exec -it b2b.devstack.analytics_pipeline.nodemanager yarn logs -applicationId $*
 
 # Provisions studio, ecommerce, and marketing with course(s) in test-course.json
 # Modify test-course.json before running this make target to generate a custom course

--- a/README.rst
+++ b/README.rst
@@ -662,7 +662,7 @@ or a manual Docker command to bring down the container:
 
 .. code:: sh
 
-   docker kill $(docker ps -a -q --filter="name=edx.devstack.<container name>")
+   docker kill $(docker ps -a -q --filter="name=b2b.devstack.<container name>")
 
 Running LMS and Studio Tests
 ----------------------------
@@ -706,7 +706,7 @@ startup, and can be found by running ``make vnc-passwords``.
 
 Most tests are run in Firefox by default.  To use Chrome for tests that normally
 use Firefox instead, prefix the test command with
-``SELENIUM_BROWSER=chrome SELENIUM_HOST=edx.devstack.chrome``.
+``SELENIUM_BROWSER=chrome SELENIUM_HOST=b2b.devstack.chrome``.
 
 Running End-to-End Tests
 ------------------------

--- a/course-generator/create-courses.sh
+++ b/course-generator/create-courses.sh
@@ -15,14 +15,14 @@ for arg in "$@"; do
             studio=true
         fi
     elif [ $arg == "--ecommerce" ]; then
-        if [ ! "$(docker exec -t edx.devstack.ecommerce bash -c 'echo "Course will be created for ecommerce"; exit $?')" ]; then
+        if [ ! "$(docker exec -t b2b.devstack.ecommerce bash -c 'echo "Course will be created for ecommerce"; exit $?')" ]; then
             echo "Issue with ecommerce container"
             container_error=true
         else
             ecommerce=true
         fi
     elif [ $arg == "--marketing" ]; then
-        if [ ! "$(docker exec -t edx.devstack.marketing bash -c 'echo "Course will be created for marketing"; exit $?')" ]; then
+        if [ ! "$(docker exec -t b2b.devstack.marketing bash -c 'echo "Course will be created for marketing"; exit $?')" ]; then
             echo "Issue with marketing container. Course creation will proceed without marketing container."
         else
             marketing=true
@@ -54,10 +54,10 @@ fi
 
 if $ecommerce ; then
 	echo "Creating courses on ecommerce."
-	docker exec -t edx.devstack.ecommerce bash -c "source /edx/app/ecommerce/ecommerce_env && python /edx/app/ecommerce/ecommerce/manage.py generate_courses '$course_json'"
+	docker exec -t b2b.devstack.ecommerce bash -c "source /edx/app/ecommerce/ecommerce_env && python /edx/app/ecommerce/ecommerce/manage.py generate_courses '$course_json'"
 fi
 
 if $marketing ; then
 	echo "Creating courses on marketing."
-	docker exec -t edx.devstack.marketing bash -c "drush generate_courses '$course_json'"
+	docker exec -t b2b.devstack.marketing bash -c "drush generate_courses '$course_json'"
 fi

--- a/docker-compose-analytics-pipeline.yml
+++ b/docker-compose-analytics-pipeline.yml
@@ -3,7 +3,7 @@ version: "2.1"
 services:
   namenode:
     image: edxops/analytics_pipeline_hadoop_namenode:${OPENEDX_RELEASE:-latest}
-    container_name: edx.devstack.analytics_pipeline.namenode
+    container_name: b2b.devstack.analytics_pipeline.namenode
     hostname: namenode
     environment:
       - CLUSTER_NAME=devstack
@@ -15,7 +15,7 @@ services:
 
   datanode:
     image: edxops/analytics_pipeline_hadoop_datanode:${OPENEDX_RELEASE:-latest}
-    container_name: edx.devstack.analytics_pipeline.datanode
+    container_name: b2b.devstack.analytics_pipeline.datanode
     hostname: datanode
     environment:
       CORE_CONF_fs_defaultFS: "hdfs://namenode:8020"
@@ -29,7 +29,7 @@ services:
 
   resourcemanager:
     image: edxops/analytics_pipeline_hadoop_resourcemanager:${OPENEDX_RELEASE:-latest}
-    container_name: edx.devstack.analytics_pipeline.resourcemanager
+    container_name: b2b.devstack.analytics_pipeline.resourcemanager
     hostname: resourcemanager
     environment:
       CORE_CONF_fs_defaultFS: "hdfs://namenode:8020"
@@ -46,7 +46,7 @@ services:
 
   nodemanager:
     image: edxops/analytics_pipeline_hadoop_nodemanager:${OPENEDX_RELEASE:-latest}
-    container_name: edx.devstack.analytics_pipeline.nodemanager
+    container_name: b2b.devstack.analytics_pipeline.nodemanager
     hostname: nodemanager
     environment:
       CORE_CONF_fs_defaultFS: "hdfs://namenode:8020"
@@ -67,7 +67,7 @@ services:
 
   sparkmaster:
     image: edxops/analytics_pipeline_spark_master:${OPENEDX_RELEASE:-latest}
-    container_name: edx.devstack.analytics_pipeline.sparkmaster
+    container_name: b2b.devstack.analytics_pipeline.sparkmaster
     hostname: sparkmaster
     ports:
       - 127.0.0.1:8080:8080
@@ -77,7 +77,7 @@ services:
 
   sparkworker:
     image: edxops/analytics_pipeline_spark_worker:${OPENEDX_RELEASE:-latest}
-    container_name: edx.devstack.analytics_pipeline.sparkworker
+    container_name: b2b.devstack.analytics_pipeline.sparkworker
     hostname: sparkworker
     depends_on:
       - sparkmaster
@@ -88,13 +88,13 @@ services:
 
   vertica:
     image: sumitchawla/vertica:latest
-    container_name: edx.devstack.analytics_pipeline.vertica
+    container_name: b2b.devstack.analytics_pipeline.vertica
     volumes:
       - vertica_data:/home/dbadmin/docker
 
   analyticspipeline:
     image: edxops/analytics_pipeline:${OPENEDX_RELEASE:-latest}
-    container_name: edx.devstack.analytics_pipeline
+    container_name: b2b.devstack.analytics_pipeline
     hostname: analyticspipeline
     volumes:
       - ${DEVSTACK_WORKSPACE}/edx-analytics-pipeline:/edx/app/analytics_pipeline/analytics_pipeline

--- a/docker-compose-host-nfs.yml
+++ b/docker-compose-host-nfs.yml
@@ -1,36 +1,6 @@
 version: "2.1"
 
 services:
-#  credentials:
-#    volumes:
-#      - ${DEVSTACK_WORKSPACE}/credentials:/edx/app/credentials/credentials:cached
-#      - credentials_node_modules:/edx/app/credentials/credentials/node_modules
-#      - src-nfs:/edx/src:cached
-#  discovery:
-#      volumes:
-#      - ${DEVSTACK_WORKSPACE}/course-discovery:/edx/app/discovery/discovery:cached
-#      - discovery_node_modules:/edx/app/discovery/discovery/node_modules
-#      - src-nfs:/edx/src:cached
-#  ecommerce:
-#    volumes:
-#      - ${DEVSTACK_WORKSPACE}/ecommerce:/edx/app/ecommerce/ecommerce:cached
-#      - ecommerce_node_modules:/edx/app/ecommerce/ecommerce/node_modules
-#      - src-nfs:/edx/src:cached
-  lms:
-    volumes:
-      - edx-nfs:/edx/app/edxapp/edx-platform
-      - src-nfs:/edx/src
-#  edx_notes_api:
-#    volumes:
-#      - ${DEVSTACK_WORKSPACE}/edx-notes-api:/edx/app/edx_notes_api/edx_notes_api:cached
-#      - src-nfs:/edx/src:cached
-  studio:
-    volumes:
-      - edx-nfs:/edx/app/edxapp/edx-platform
-      - src-nfs:/edx/src
-  forum:
-    volumes:
-      - ${DEVSTACK_WORKSPACE}/cs_comments_service:/edx/app/forum/cs_comments_service:cached
   edraak_programs:
     volumes:
       - progs-nfs:/app
@@ -41,35 +11,14 @@ services:
       - progs-nfs:/app
       - ~/.ssh/:/root/.ssh
       - src-nfs:/edx/src
-  edraak_marketing:
-    volumes:
-      - marketing-nfs:/app
-  edraak_marketing_gulp:
-    volumes:
-      - marketing-nfs:/app
 
 volumes:
-#  credentials_node_modules:
-#  discovery_node_modules:
-#  ecommerce_node_modules:
-  edx-nfs:
-    driver: local
-    driver_opts:
-      type: nfs
-      o: addr=host.docker.internal,rw,nolock,hard,nointr,nfsvers=3
-      device: :${DEVSTACK_WORKSPACE}/edx-platform
   src-nfs:
     driver: local
     driver_opts:
       type: nfs
       o: addr=host.docker.internal,rw,nolock,hard,nointr,nfsvers=3
       device: :${DEVSTACK_WORKSPACE}/src
-  marketing-nfs:
-    driver: local
-    driver_opts:
-      type: nfs
-      o: addr=host.docker.internal,rw,nolock,hard,nointr,nfsvers=3
-      device: :${DEVSTACK_WORKSPACE}/marketing-site
   progs-nfs:
     driver: local
     driver_opts:

--- a/docker-compose-host-nfs.yml
+++ b/docker-compose-host-nfs.yml
@@ -35,10 +35,12 @@ services:
     volumes:
       - progs-nfs:/app
       - ~/.ssh/:/root/.ssh
+      - src-nfs:/edx/src
   edraak_programs_gulp:
     volumes:
       - progs-nfs:/app
       - ~/.ssh/:/root/.ssh
+      - src-nfs:/edx/src
   edraak_marketing:
     volumes:
       - marketing-nfs:/app

--- a/docker-compose-host.yml
+++ b/docker-compose-host.yml
@@ -11,8 +11,3 @@ services:
       - ${DEVSTACK_WORKSPACE}/edraak-programs:/app:cached
       - ~/.ssh/:/root/.ssh
       - ${DEVSTACK_WORKSPACE}/src:/src:cached
-
-volumes:
-#  credentials_node_modules:
-#  discovery_node_modules:
-#  ecommerce_node_modules:

--- a/docker-compose-host.yml
+++ b/docker-compose-host.yml
@@ -1,38 +1,6 @@
 version: "2.1"
 
 services:
-#  credentials:
-#    volumes:
-#      - ${DEVSTACK_WORKSPACE}/credentials:/edx/app/credentials/credentials:cached
-#      - credentials_node_modules:/edx/app/credentials/credentials/node_modules
-#      - ${DEVSTACK_WORKSPACE}/src:/edx/src:cached
-#  discovery:
-#      volumes:
-#      - ${DEVSTACK_WORKSPACE}/course-discovery:/edx/app/discovery/discovery:cached
-#      - discovery_node_modules:/edx/app/discovery/discovery/node_modules
-#      - ${DEVSTACK_WORKSPACE}/src:/edx/src:cached
-#  ecommerce:
-#    volumes:
-#      - ${DEVSTACK_WORKSPACE}/ecommerce:/edx/app/ecommerce/ecommerce:cached
-#      - ecommerce_node_modules:/edx/app/ecommerce/ecommerce/node_modules
-#      - ${DEVSTACK_WORKSPACE}/src:/edx/src:cached
-  lms:
-    volumes:
-      - ${DEVSTACK_WORKSPACE}/edx-platform:/edx/app/edxapp/edx-platform:cached
-      - edxapp_node_modules:/edx/app/edxapp/edx-platform/node_modules
-      - ${DEVSTACK_WORKSPACE}/src:/edx/src:cached
-#  edx_notes_api:
-#    volumes:
-#      - ${DEVSTACK_WORKSPACE}/edx-notes-api:/edx/app/edx_notes_api/edx_notes_api:cached
-#      - ${DEVSTACK_WORKSPACE}/src:/edx/src:cached
-  studio:
-    volumes:
-      - ${DEVSTACK_WORKSPACE}/edx-platform:/edx/app/edxapp/edx-platform:cached
-      - edxapp_node_modules:/edx/app/edxapp/edx-platform/node_modules
-      - ${DEVSTACK_WORKSPACE}/src:/edx/src:cached
-  forum:
-    volumes:
-      - ${DEVSTACK_WORKSPACE}/cs_comments_service:/edx/app/forum/cs_comments_service:cached
   edraak_programs:
     volumes:
       - ${DEVSTACK_WORKSPACE}/edraak-programs:/app:cached
@@ -43,15 +11,8 @@ services:
       - ${DEVSTACK_WORKSPACE}/edraak-programs:/app:cached
       - ~/.ssh/:/root/.ssh
       - ${DEVSTACK_WORKSPACE}/src:/src:cached
-  edraak_marketing:
-    volumes:
-      - ${DEVSTACK_WORKSPACE}/marketing-site:/app:cached
-  edraak_marketing_gulp:
-    volumes:
-      - ${DEVSTACK_WORKSPACE}/marketing-site:/app:cached
 
 volumes:
 #  credentials_node_modules:
 #  discovery_node_modules:
 #  ecommerce_node_modules:
-  edxapp_node_modules:

--- a/docker-compose-host.yml
+++ b/docker-compose-host.yml
@@ -37,10 +37,12 @@ services:
     volumes:
       - ${DEVSTACK_WORKSPACE}/edraak-programs:/app:cached
       - ~/.ssh/:/root/.ssh
+      - ${DEVSTACK_WORKSPACE}/src:/src:cached
   edraak_programs_gulp:
     volumes:
       - ${DEVSTACK_WORKSPACE}/edraak-programs:/app:cached
       - ~/.ssh/:/root/.ssh
+      - ${DEVSTACK_WORKSPACE}/src:/src:cached
   edraak_marketing:
     volumes:
       - ${DEVSTACK_WORKSPACE}/marketing-site:/app:cached

--- a/docker-compose-marketing-site.yml
+++ b/docker-compose-marketing-site.yml
@@ -7,17 +7,17 @@ services:
       - MARKETING_SITE_ROOT="http://localhost:8080"
 
   marketing:
-    container_name: edx.devstack.marketing
+    container_name: b2b.devstack.marketing
     depends_on:
       - mysql
       - memcached
     environment:
-      - DB_HOST=edx.devstack.mysql
+      - DB_HOST=b2b.devstack.mysql
       - DB_NAME=edxmktg
       - DB_PASSWORD=password
       - DB_USER=edxmktg001
       - LMS_HOST=http://localhost:18000
-      - MEMCACHE_HOST=edx.devstack.memcached
+      - MEMCACHE_HOST=b2b.devstack.memcached
       # Used by PhpStorm to attach the debug connection
       - PHP_IDE_CONFIG=serverName=edx.docker
       # For the settings below, see .env.example to provide values (default is after the ':-')

--- a/docker-compose-watchers-nfs.yml
+++ b/docker-compose-watchers-nfs.yml
@@ -3,9 +3,9 @@ version: "2.1"
 services:
   lms_watcher:
     command: bash -c 'cd /edx/app/edxapp/edx-platform && source ../edxapp_env && while true; do paver watch_assets $$EXTRA --w=$$ASSET_WATCHER_TIMEOUT; sleep 2; done'
-    container_name: edx.devstack.lms_watcher
+    container_name: b2b.devstack.lms_watcher
     environment:
-      BOK_CHOY_HOSTNAME: edx.devstack.lms_watcher
+      BOK_CHOY_HOSTNAME: b2b.devstack.lms_watcher
       ASSET_WATCHER_TIMEOUT: 12
       EXTRA: '--themes edraak-2019-theme --theme-dirs /edx/src'
     image: eu.gcr.io/openedx-231314/edraak/edxapp:hawthorn.edraak.v3
@@ -16,9 +16,9 @@ services:
 
   studio_watcher:
     command: bash -c 'cd /edx/app/edxapp/edx-platform && source ../edxapp_env && while true; do paver watch_assets $$EXTRA --w=$$ASSET_WATCHER_TIMEOUT; sleep 2; done'
-    container_name: edx.devstack.studio_watcher
+    container_name: b2b.devstack.studio_watcher
     environment:
-      BOK_CHOY_HOSTNAME: edx.devstack.studio_watcher
+      BOK_CHOY_HOSTNAME: b2b.devstack.studio_watcher
       ASSET_WATCHER_TIMEOUT: 12
       EXTRA: '--themes edraak-2019-theme --theme-dirs /edx/src'
     image: eu.gcr.io/openedx-231314/edraak/edxapp:hawthorn.edraak.v3

--- a/docker-compose-watchers.yml
+++ b/docker-compose-watchers.yml
@@ -3,9 +3,9 @@ version: "2.1"
 services:
   lms_watcher:
     command: bash -c 'cd /edx/app/edxapp/edx-platform && source ../edxapp_env && while true; do paver watch_assets $$EXTRA --w=$$ASSET_WATCHER_TIMEOUT; sleep 2; done'
-    container_name: edx.devstack.lms_watcher
+    container_name: b2b.devstack.lms_watcher
     environment:
-      BOK_CHOY_HOSTNAME: edx.devstack.lms_watcher
+      BOK_CHOY_HOSTNAME: b2b.devstack.lms_watcher
       ASSET_WATCHER_TIMEOUT: 12
       EXTRA: '--themes edraak-2019-theme --theme-dirs /edx/app/edx-themes'
     image: eu.gcr.io/openedx-231314/edraak/edxapp:hawthorn.edraak.v3
@@ -17,9 +17,9 @@ services:
 
   studio_watcher:
     command: bash -c 'cd /edx/app/edxapp/edx-platform && source ../edxapp_env && while true; do paver watch_assets $$EXTRA --w=$$ASSET_WATCHER_TIMEOUT; sleep 2; done'
-    container_name: edx.devstack.studio_watcher
+    container_name: b2b.devstack.studio_watcher
     environment:
-      BOK_CHOY_HOSTNAME: edx.devstack.studio_watcher
+      BOK_CHOY_HOSTNAME: b2b.devstack.studio_watcher
       ASSET_WATCHER_TIMEOUT: 12
       EXTRA: '--themes edraak-2019-theme --theme-dirs /edx/app/edx-themes'
     image: eu.gcr.io/openedx-231314/edraak/edxapp:hawthorn.edraak.v3

--- a/docker-compose-xqueue.yml
+++ b/docker-compose-xqueue.yml
@@ -2,7 +2,7 @@ version: "2.1"
 
 services:
   xqueue:
-    container_name: edx.devstack.xqueue
+    container_name: b2b.devstack.xqueue
     image: edxops/xqueue:${OPENEDX_RELEASE:-latest}
     command: bash -c 'source /edx/app/xqueue/xqueue_env && while true; do python /edx/app/xqueue/xqueue/manage.py runserver 0.0.0.0:18040 ; sleep 2; done'
     volumes:
@@ -12,7 +12,7 @@ services:
       - 18040:18040
 
   xqueue_consumer:
-    container_name: edx.devstack.xqueue_consumer
+    container_name: b2b.devstack.xqueue_consumer
     image: edxops/xqueue:${OPENEDX_RELEASE:-latest}
     command: bash -c 'source /edx/app/xqueue/xqueue_env && while true; do python /edx/app/xqueue/xqueue/manage.py run_consumer ; sleep 2; done'
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,7 +83,7 @@ services:
   edraak_programs:
     image: eu.gcr.io/openedx-231314/edraak/progs
     environment:
-      PROGS_CFG: '/app/docker.json'
+      PROGS_CFG: ${PROGS_CFG}
       NODE_ENV: development
     command: bash -c 'while true; do python manage.py runserver 0.0.0.0:8800 --settings=edraakprograms.dev; sleep 2; done'
     container_name: b2b.devstack.programs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,9 +108,7 @@ services:
 
   edraak_dev_router:
     image: nginx
-    container_name: edraak_dev_router
-    logging:
-      driver: none
+    container_name: edraak_b2b_dev_router
     volumes:
       - ./nginx:/etc/nginx/conf.d
     command: bash -c 'while true; do nginx -g "daemon off;"; sleep 2; done'
@@ -122,7 +120,7 @@ services:
     networks:
       default:
         aliases:
-          - programs.edraak.dev
+          - b2b.edraak.dev
           - edraak.dev
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@
 # - Group third-party and edX services separately
 # - Alphabetize services in the groups
 # - Alphabetize individual configuration options for each service
-# - Every service's container name should be prefixed with "edx.devstack." to avoid conflicts with other containers
+# - Every service's container name should be prefixed with "b2b.devstack." to avoid conflicts with other containers
 #   that might be running for the same service.
 
 version: "2.1"
@@ -13,7 +13,7 @@ version: "2.1"
 services:
   # Third-party services
 #  chrome:
-#    container_name: edx.devstack.chrome
+#    container_name: b2b.devstack.chrome
 #    image: edxops/chrome:${OPENEDX_RELEASE:-latest}
 #    shm_size: 2g
 #    ports:
@@ -23,7 +23,7 @@ services:
 #      - ../edx-platform/common/test/data:/edx/app/edxapp/edx-platform/common/test/data
 
   elasticsearch:
-    container_name: edx.devstack.elasticsearch
+    container_name: b2b.devstack.elasticsearch
     image: edxops/elasticsearch:devstack
     ports:
        - "9200:9200"
@@ -33,7 +33,7 @@ services:
       - elasticsearch_data:/usr/share/elasticsearch/logs
 
 #  firefox:
-#    container_name: edx.devstack.firefox
+#    container_name: b2b.devstack.firefox
 #    image: edxops/firefox:${OPENEDX_RELEASE:-latest}
 #    shm_size: 2g
 #    ports:
@@ -43,7 +43,7 @@ services:
 #      - ../edx-platform/common/test/data:/edx/app/edxapp/edx-platform/common/test/data
 
   memcached:
-    container_name: edx.devstack.memcached
+    container_name: b2b.devstack.memcached
     image: memcached:1.4.24
     ports:
        - "11211:11211"
@@ -53,7 +53,7 @@ services:
     # to conserve disk space, and disable the journal for a minor performance gain.
     # See https://docs.mongodb.com/v3.0/reference/program/mongod/#options for complete details.
     command: mongod --smallfiles --nojournal --storageEngine wiredTiger
-    container_name: edx.devstack.mongo
+    container_name: b2b.devstack.mongo
     image: mongo:3.6.17
     ports:
       - "27017:27017"
@@ -62,7 +62,7 @@ services:
 
   mysql:
     command: mysqld --character-set-server=utf8 --collation-server=utf8_general_ci
-    container_name: edx.devstack.mysql
+    container_name: b2b.devstack.mysql
     environment:
       MYSQL_ROOT_PASSWORD: ""
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
@@ -72,144 +72,8 @@ services:
     volumes:
       - mysql_data:/var/lib/mysql
 
-#  # edX services
-#  credentials:
-#    command: bash -c 'source /edx/app/credentials/credentials_env && while true; do python /edx/app/credentials/credentials/manage.py runserver 0.0.0.0:18150; sleep 2; done'
-#    container_name: edx.devstack.credentials
-#    depends_on:
-#      - mysql
-#      - memcached
-#    # Allows attachment to the credentials service using 'docker attach <containerID>'.
-#    stdin_open: true
-#    tty: true
-#    environment:
-#      CACHE_LOCATION: edx.devstack.memcached:12211
-#      DB_HOST: edx.devstack.mysql
-#      SOCIAL_AUTH_EDX_OIDC_URL_ROOT: http://edx.devstack.lms:18000/oauth2
-#      ENABLE_DJANGO_TOOLBAR: 1
-#    image: edxops/credentials:${OPENEDX_RELEASE:-latest}
-#    ports:
-#      - "18150:18150"
-
-#  discovery:
-#    command: bash -c 'source /edx/app/discovery/discovery_env && while true; do python /edx/app/discovery/discovery/manage.py runserver 0.0.0.0:18381; sleep 2; done'
-#    container_name: edx.devstack.discovery
-#    depends_on:
-#      - mysql
-#      - elasticsearch
-#      - memcached
-#    # Allows attachment to the discovery service using 'docker attach <containerID>'.
-#    stdin_open: true
-#    tty: true
-#    environment:
-#      TEST_ELASTICSEARCH_URL: "http://edx.devstack.elasticsearch:9200"
-#      ENABLE_DJANGO_TOOLBAR: 1
-#    image: edxops/discovery:${OPENEDX_RELEASE:-latest}
-#    ports:
-#      - "18381:18381"
-#    volumes:
-#      - discovery_assets:/edx/var/discovery/
-
-#  ecommerce:
-#    command: bash -c 'source /edx/app/ecommerce/ecommerce_env && while true; do python /edx/app/ecommerce/ecommerce/manage.py runserver 0.0.0.0:18130; sleep 2; done'
-#    container_name: edx.devstack.ecommerce
-#    depends_on:
-#      - mysql
-#      - memcached
-#    # Allows attachment to the ecommerce service using 'docker attach <containerID>'.
-#    stdin_open: true
-#    tty: true
-#    environment:
-#      ENABLE_DJANGO_TOOLBAR: 0
-#    image: edxops/ecommerce:${OPENEDX_RELEASE:-latest}
-#    ports:
-#      - "18130:18130"
-
-  lms:
-    command: bash -c 'source /edx/app/edxapp/edxapp_env && while true; do python /edx/app/edxapp/edx-platform/manage.py lms runserver 0.0.0.0:18000 --settings devstack_docker; sleep 2; done'
-    container_name: edx.devstack.lms
-    depends_on:
-      - devpi
-      - mysql
-      - memcached
-      - mongo
-    # Allows attachment to the LMS service using 'docker attach <containerID>'.
-    stdin_open: true
-    tty: true
-    environment:
-      BOK_CHOY_HOSTNAME: edx.devstack.lms
-      BOK_CHOY_LMS_PORT: 18003
-      BOK_CHOY_CMS_PORT: 18031
-      EDXAPP_TEST_MONGO_HOST: edx.devstack.mongo
-      NO_PYTHON_UNINSTALL: 1
-    image: eu.gcr.io/openedx-231314/edraak/edxapp:hawthorn.edraak.v3
-    ports:
-      - "18000:18000"
-      - "19876:19876" # JS test debugging
-      - "18003:18003"
-      - "18031:18031"
-    volumes:
-      - edxapp_lms_assets:/edx/var/edxapp/staticfiles/
-
-#  edx_notes_api:
-#    command: bash -c 'source /edx/app/edx_notes_api/edx_notes_api_env && while true; do python /edx/app/edx_notes_api/edx_notes_api/manage.py runserver 0.0.0.0:18120 --settings notesserver.settings.devstack; sleep 2; done'
-#    container_name: edx.devstack.edx_notes_api
-#    depends_on:
-#      - devpi
-#      - elasticsearch
-#      - mysql
-#    image: edxops/notes:${OPENEDX_RELEASE:-latest}
-#    ports:
-#      - "18120:18120"
-#    environment:
-#      DB_ENGINE: "django.db.backends.mysql"
-#      DB_HOST: "edx.devstack.mysql"
-#      DB_NAME: "notes"
-#      DB_PASSWORD: "password"
-#      DB_PORT: "3306"
-#      DB_USER: "notes001"
-#      ENABLE_DJANGO_TOOLBAR: 1
-#      ELASTICSEARCH_URL: "http://edx.devstack.elasticsearch:9200"
-
-  studio:
-    command: bash -c 'source /edx/app/edxapp/edxapp_env && while true; do python /edx/app/edxapp/edx-platform/manage.py cms runserver 0.0.0.0:18010 --settings devstack_docker; sleep 2; done'
-    container_name: edx.devstack.studio
-    depends_on:
-      - devpi
-      - mysql
-      - memcached
-      - mongo
-    # Allows attachment to the Studio service using 'docker attach <containerID>'.
-    stdin_open: true
-    tty: true
-    environment:
-      BOK_CHOY_HOSTNAME: edx.devstack.studio
-      BOK_CHOY_LMS_PORT: 18103
-      BOK_CHOY_CMS_PORT: 18131
-      EDXAPP_TEST_MONGO_HOST: edx.devstack.mongo
-      NO_PYTHON_UNINSTALL: 1
-    image: eu.gcr.io/openedx-231314/edraak/edxapp:hawthorn.edraak.v3
-    ports:
-      - "18010:18010"
-      - "19877:19877" # JS test debugging
-      - "18103:18103"
-      - "18131:18131"
-    volumes:
-      - edxapp_studio_assets:/edx/var/edxapp/staticfiles/
-
-  forum:
-    command: bash -c 'source /edx/app/forum/ruby_env && source /edx/app/forum/devstack_forum_env && cd /edx/app/forum/cs_comments_service && bundle install && while true; do ruby app.rb -o 0.0.0.0 ; sleep 2; done'
-    container_name: edx.devstack.forum
-    depends_on:
-      - mongo
-      - memcached
-      - elasticsearch
-    image: edxops/forum:${OPENEDX_RELEASE:-latest}
-    ports:
-      - "44567:4567"
-
   devpi:
-    container_name: edx.devstack.devpi
+    container_name: b2b.devstack.devpi
     image: edxops/devpi:${OPENEDX_RELEASE:-latest}
     ports:
       - "3141:3141"
@@ -222,7 +86,7 @@ services:
       PROGS_CFG: '/app/docker.json'
       NODE_ENV: development
     command: bash -c 'while true; do python manage.py runserver 0.0.0.0:8800 --settings=edraakprograms.dev; sleep 2; done'
-    container_name: edraak.devstack.programs
+    container_name: b2b.devstack.programs
     working_dir: /app
     ports:
       - "18800:8800"
@@ -236,31 +100,7 @@ services:
     environment:
       NODE_ENV: development
     command: bash -c 'while true; do npx gulp watch; sleep 2; done'
-    container_name: edraak.devstack.programs-gulp
-    working_dir: /app
-    depends_on:
-      - mysql
-      - memcached
-
-  edraak_marketing:
-    image: eu.gcr.io/openedx-231314/edraak/marketing
-    environment:
-      NODE_ENV: development
-    command: bash -c 'while true; do python manage.py runserver 0.0.0.0:8500 --settings=marketingsite.envs.dev; sleep 2; done'
-    container_name: edraak.devstack.marketing
-    working_dir: /app
-    ports:
-      - "18500:8500"
-    depends_on:
-      - mysql
-      - memcached
-
-  edraak_marketing_gulp:
-    image: eu.gcr.io/openedx-231314/edraak/marketing
-    environment:
-      NODE_ENV: development
-    command: bash -c 'while true; do npx gulp watch; sleep 2; done'
-    container_name: edraak.devstack.marketing-gulp
+    container_name: b2b.devstack.programs-gulp
     working_dir: /app
     depends_on:
       - mysql
@@ -278,23 +118,16 @@ services:
       - "80:80"
       - "443:443"
     depends_on:
-      - lms
-      - studio
-      - edraak_marketing
       - edraak_programs
     networks:
       default:
         aliases:
-          - www.edraak.dev
-          - courses.edraak.dev
           - programs.edraak.dev
           - edraak.dev
 
 
 volumes:
 #  discovery_assets:
-  edxapp_lms_assets:
-  edxapp_studio_assets:
   elasticsearch_data:
   mongo_data:
   mysql_data:

--- a/docker-sync-marketing-site.yml
+++ b/docker-sync-marketing-site.yml
@@ -24,13 +24,3 @@ syncs:
     src: '../ecommerce/'
     sync_excludes: [ '.git', '.idea', 'node_modules', 'assets', 'ecommerce/static/bower_components', 'ecommerce/static/build' ]
 
-  edxapp-sync:
-    host_disk_mount_mode: 'cached'
-    src: '../edx-platform/'
-    sync_excludes: [ '.git', '.idea', 'node_modules', '.prereqs_cache' ]
-
-  marketing-sync:
-    host_disk_mount_mode: 'cached'
-    src: '../edx-mktg/docroot/'
-    sync_excludes: [ '.git', '.idea', 'node_modules', ]
-    sync_userid: 33

--- a/docker-sync.yml
+++ b/docker-sync.yml
@@ -20,21 +20,6 @@ syncs:
 #    src: '../ecommerce/'
 #    sync_excludes: [ '.git', '.idea' ]
 
-  edxapp-sync:
-    host_disk_mount_mode: 'cached'
-    src: '../edx-platform/'
-    sync_excludes: [ '.idea' ]
-
-  forum-sync:
-    host_disk_mount_mode: 'cached'
-    src: '../cs_comments_service/'
-    sync_excludes: [ '.git', '.idea' ]
-
-  edraak-marketing-sync:
-    host_disk_mount_mode: 'cached'
-    src: '../marketing-site/'
-    sync_excludes: [ '.git', '.idea']
-
   edraak-programs-sync:
     host_disk_mount_mode: 'cached'
     src: '../edraak-programs/'

--- a/docs/devpi.rst
+++ b/docs/devpi.rst
@@ -60,6 +60,6 @@ Monitoring devpi
 ----------------
 
 You can monitor the devpi logs by running this command on the host:
-``docker logs -f edx.devstack.devpi`` or looking at the output in
+``docker logs -f b2b.devstack.devpi`` or looking at the output in
 Kitematic. You can also check the devpi server status by visiting:
 http://localhost:3141/+status

--- a/dump-db.sh
+++ b/dump-db.sh
@@ -14,5 +14,5 @@ then
 fi
 
 echo "Dumping the $1 database..."
-docker exec -i edx.devstack.mysql mysqldump --add-drop-database --skip-add-drop-table -B $1 > $1.sql
+docker exec -i b2b.devstack.mysql mysqldump --add-drop-database --skip-add-drop-table -B $1 > $1.sql
 echo "Finished dumping the $1 database!"

--- a/ecommerce.sql
+++ b/ecommerce.sql
@@ -1006,7 +1006,7 @@ CREATE TABLE `core_siteconfiguration` (
 
 LOCK TABLES `core_siteconfiguration` WRITE;
 /*!40000 ALTER TABLE `core_siteconfiguration` DISABLE KEYS */;
-INSERT INTO `core_siteconfiguration` VALUES (1,'http://edx.devstack.lms:18000',NULL,'cybersource,paypal',1,1,'{\"SOCIAL_AUTH_EDX_OIDC_ID_TOKEN_DECRYPTION_KEY\":\"ecommerce-secret\",\"SOCIAL_AUTH_EDX_OIDC_URL_ROOT\":\"http://edx.devstack.lms:18000/oauth2\",\"SOCIAL_AUTH_EDX_OIDC_ISSUERS\":[\"http://edx.devstack.lms:18000\"],\"SOCIAL_AUTH_EDX_OIDC_KEY\":\"ecommerce-key\",\"SOCIAL_AUTH_EDX_OIDC_SECRET\":\"ecommerce-secret\"}',NULL,'staff@example.com',0,'support@example.com','','','','cybersource',0,0,'','','',1,'',0,'',0,'http://edx.devstack.discovery:18381/api/v1/',0,0);
+INSERT INTO `core_siteconfiguration` VALUES (1,'http://b2b.devstack.lms:18000',NULL,'cybersource,paypal',1,1,'{\"SOCIAL_AUTH_EDX_OIDC_ID_TOKEN_DECRYPTION_KEY\":\"ecommerce-secret\",\"SOCIAL_AUTH_EDX_OIDC_URL_ROOT\":\"http://b2b.devstack.lms:18000/oauth2\",\"SOCIAL_AUTH_EDX_OIDC_ISSUERS\":[\"http://b2b.devstack.lms:18000\"],\"SOCIAL_AUTH_EDX_OIDC_KEY\":\"ecommerce-key\",\"SOCIAL_AUTH_EDX_OIDC_SECRET\":\"ecommerce-secret\"}',NULL,'staff@example.com',0,'support@example.com','','','','cybersource',0,0,'','','',1,'',0,'',0,'http://b2b.devstack.discovery:18381/api/v1/',0,0);
 /*!40000 ALTER TABLE `core_siteconfiguration` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/load-db.sh
+++ b/load-db.sh
@@ -17,5 +17,5 @@ then
 fi
 
 echo "Loading the $1 database..."
-docker exec -i edx.devstack.mysql mysql -uroot $1 < $1.sql
+docker exec -i b2b.devstack.mysql mysql -uroot $1 < $1.sql
 echo "Finished loading the $1 database!"

--- a/marketing.mk
+++ b/marketing.mk
@@ -3,7 +3,7 @@ help-marketing: ## Display this help message
 	@perl -nle'print $& if m{^[\.a-zA-Z_-]+:.*?## .*$$}' $(MAKEFILE_LIST) | grep marketing | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m  %-25s\033[0m %s\n", $$1, $$2}'
 
 marketing-shell: ## Run a shell on the marketing site container
-	docker exec -it edx.devstack.marketing env TERM=$(TERM) bash
+	docker exec -it b2b.devstack.marketing env TERM=$(TERM) bash
 
 stop-marketing:   ## Stop all services (including the marketing site) with host volumes
 	docker-compose -f docker-compose.yml -f docker-compose-host.yml -f docker-compose-marketing-site.yml -f docker-compose-marketing-site-host.yml stop

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -40,7 +40,7 @@ server {
     include /etc/nginx/conf.d/includes/server.conf;
 
     location / {
-        proxy_pass http://edx.devstack.lms:18000;
+        proxy_pass http://b2b.devstack.lms:18000;
         include /etc/nginx/conf.d/includes/proxy.conf;
     }
 }
@@ -50,7 +50,7 @@ server {
     include /etc/nginx/conf.d/includes/server.conf;
 
     location / {
-        proxy_pass http://edx.devstack.studio:18010;
+        proxy_pass http://b2b.devstack.studio:18010;
         include /etc/nginx/conf.d/includes/proxy.conf;
     }
 }

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -11,46 +11,16 @@ server {
     include /etc/nginx/conf.d/includes/server.conf;
 
     location / {
-        return 301 https://www.edraak.dev$request_uri;
+        return 301 https://b2b.edraak.dev$request_uri;
     }
 }
 
 server {
-    server_name www.edraak.dev;
+    server_name b2b.edraak.dev;
     include /etc/nginx/conf.d/includes/server.conf;
 
     location / {
-        proxy_pass http://edraak.devstack.marketing:8500;
-        include /etc/nginx/conf.d/includes/proxy.conf;
-    }
-}
-
-server {
-    server_name programs.edraak.dev;
-    include /etc/nginx/conf.d/includes/server.conf;
-
-    location / {
-        proxy_pass http://edraak.devstack.programs:8800;
-        include /etc/nginx/conf.d/includes/proxy.conf;
-    }
-}
-
-server {
-    server_name courses.edraak.dev;
-    include /etc/nginx/conf.d/includes/server.conf;
-
-    location / {
-        proxy_pass http://b2b.devstack.lms:18000;
-        include /etc/nginx/conf.d/includes/proxy.conf;
-    }
-}
-
-server {
-    server_name studio.edraak.dev;
-    include /etc/nginx/conf.d/includes/server.conf;
-
-    location / {
-        proxy_pass http://b2b.devstack.studio:18010;
+        proxy_pass http://b2b.devstack.programs:8800;
         include /etc/nginx/conf.d/includes/proxy.conf;
     }
 }

--- a/programs/discovery.py
+++ b/programs/discovery.py
@@ -8,7 +8,7 @@ from course_discovery.apps.course_metadata.models import (
     Course, CourseRun, Organization, Program, ProgramType, SeatType
 )
 
-DEMO_IMAGE_URL = 'http://edx.devstack.lms:18000/asset-v1:edX+DemoX+Demo_Course+type@asset+block@images_course_image.jpg'
+DEMO_IMAGE_URL = 'http://b2b.devstack.lms:18000/asset-v1:edX+DemoX+Demo_Course+type@asset+block@images_course_image.jpg'
 
 
 # Make sure micromasters type exists

--- a/programs/lms.py
+++ b/programs/lms.py
@@ -7,7 +7,7 @@ from openedx.core.djangoapps.catalog.models import CatalogIntegration
 from openedx.core.djangoapps.programs.models import ProgramsApiConfig
 from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
 
-DISCOVERY_API_URL = 'http://edx.devstack.discovery:18381/api/v1/'
+DISCOVERY_API_URL = 'http://b2b.devstack.discovery:18381/api/v1/'
 
 
 def set_current_config(cls, args):

--- a/provision-analytics-pipeline.sh
+++ b/provision-analytics-pipeline.sh
@@ -21,7 +21,7 @@ docker-compose $DOCKER_COMPOSE_FILES up -d mysql analyticspipeline
 
 # Ensure the MySQL server is online and usable
 echo "Waiting for MySQL"
-until docker exec -i edx.devstack.mysql mysql -uroot -se "SELECT EXISTS(SELECT 1 FROM mysql.user WHERE user = 'root')" &> /dev/null
+until docker exec -i b2b.devstack.mysql mysql -uroot -se "SELECT EXISTS(SELECT 1 FROM mysql.user WHERE user = 'root')" &> /dev/null
 do
   printf "."
   sleep 1
@@ -34,12 +34,12 @@ sleep 20
 # Analytics pipeline has dependency on lms but we only need its db schema & not full lms. So we'll just load their db
 # schemas as part of analytics pipeline provisioning. If there is a need of a fully fledged LMS, then provision lms
 # by following their documentation.
-if [[ ! -z "`docker exec -i edx.devstack.mysql mysql -uroot -se "SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME='edxapp'" 2>&1`" ]];
+if [[ ! -z "`docker exec -i b2b.devstack.mysql mysql -uroot -se "SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME='edxapp'" 2>&1`" ]];
 then
   echo -e "${GREEN}LMS DB exists, skipping lms schema load.${NC}"
 else
   echo -e "${GREEN}LMS DB not found, provisioning lms schema.${NC}"
-  docker exec -i edx.devstack.mysql mysql -uroot mysql < provision.sql
+  docker exec -i b2b.devstack.mysql mysql -uroot mysql < provision.sql
   ./load-db.sh edxapp
   docker-compose $DOCKER_COMPOSE_FILES up -d lms studio
   docker-compose exec lms bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform && NO_PYTHON_UNINSTALL=1 paver install_prereqs'
@@ -51,7 +51,7 @@ fi
 
 echo -e "${GREEN}LMS database provisioned successfully...${NC}"
 echo -e "${GREEN}Creating databases and users...${NC}"
-docker exec -i edx.devstack.mysql mysql -uroot mysql < provision-analytics-pipeline.sql
+docker exec -i b2b.devstack.mysql mysql -uroot mysql < provision-analytics-pipeline.sql
 
 # initialize hive metastore
 echo -e "${GREEN}Initializing HIVE metastore...${NC}"
@@ -68,7 +68,7 @@ done
 sleep 10 # for datanode & other services to activate
 echo -e "${GREEN}Namenode is ready!${NC}"
 
-docker exec -u hadoop -i edx.devstack.analytics_pipeline bash -c 'sudo /edx/app/hadoop/hadoop/bin/hdfs dfs -chown -R hadoop:hadoop hdfs://namenode:8020/; hdfs dfs -mkdir -p hdfs://namenode:8020/edx-analytics-pipeline/{warehouse,marker,manifest,packages} hdfs://namenode:8020/{spark-warehouse,data} hdfs://namenode:8020/tmp/spark-events;hdfs dfs -copyFromLocal -f /edx/app/hadoop/lib/edx-analytics-hadoop-util.jar hdfs://namenode:8020/edx-analytics-pipeline/packages/;'
+docker exec -u hadoop -i b2b.devstack.analytics_pipeline bash -c 'sudo /edx/app/hadoop/hadoop/bin/hdfs dfs -chown -R hadoop:hadoop hdfs://namenode:8020/; hdfs dfs -mkdir -p hdfs://namenode:8020/edx-analytics-pipeline/{warehouse,marker,manifest,packages} hdfs://namenode:8020/{spark-warehouse,data} hdfs://namenode:8020/tmp/spark-events;hdfs dfs -copyFromLocal -f /edx/app/hadoop/lib/edx-analytics-hadoop-util.jar hdfs://namenode:8020/edx-analytics-pipeline/packages/;'
 
 docker image prune -f
 

--- a/provision-credentials.sh
+++ b/provision-credentials.sh
@@ -9,20 +9,20 @@ port=18150
 docker-compose $DOCKER_COMPOSE_FILES up -d $name
 
 echo -e "${GREEN}Installing requirements for ${name}...${NC}"
-docker exec -t edx.devstack.${name}  bash -c 'source /edx/app/credentials/credentials_env && cd /edx/app/credentials/credentials && make requirements && make production-requirements' -- "$name"
+docker exec -t b2b.devstack.${name}  bash -c 'source /edx/app/credentials/credentials_env && cd /edx/app/credentials/credentials && make requirements && make production-requirements' -- "$name"
 
 echo -e "${GREEN}Running migrations for ${name}...${NC}"
-docker exec -t edx.devstack.${name}  bash -c 'source /edx/app/credentials/credentials_env && cd /edx/app/credentials/credentials && make migrate' -- "$name"
+docker exec -t b2b.devstack.${name}  bash -c 'source /edx/app/credentials/credentials_env && cd /edx/app/credentials/credentials && make migrate' -- "$name"
 
 echo -e "${GREEN}Creating super-user for ${name}...${NC}"
-docker exec -t edx.devstack.${name}  bash -c 'source /edx/app/credentials/credentials_env && cd /edx/app/credentials/credentials && echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser(\"edx\", \"edx@example.com\", \"edx\") if not User.objects.filter(username=\"edx\").exists() else None" | python /edx/app/$1/$1/manage.py shell' -- "$name"
+docker exec -t b2b.devstack.${name}  bash -c 'source /edx/app/credentials/credentials_env && cd /edx/app/credentials/credentials && echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser(\"edx\", \"edx@example.com\", \"edx\") if not User.objects.filter(username=\"edx\").exists() else None" | python /edx/app/$1/$1/manage.py shell' -- "$name"
 
 echo -e "${GREEN}Configuring site for ${name}...${NC}"
-docker exec -t edx.devstack.${name} bash -c 'source /edx/app/credentials/credentials_env && cd /edx/app/credentials/ && ./manage.py create_or_update_site --site-id=1 --site-domain=localhost:18150 --site-name="Open edX" --platform-name="Open edX" --company-name="Open edX" --lms-url-root=http://localhost:18000 --catalog-api-url=http://edx.devstack.discovery:18381/api/v1/ --tos-url=http://localhost:18000/tos --privacy-policy-url=http://localhost:18000/privacy --homepage-url=http://localhost:18000 --certificate-help-url=http://localhost:18000/faq --records-help-url=http://localhost:18000/faq --theme-name=openedx'
+docker exec -t b2b.devstack.${name} bash -c 'source /edx/app/credentials/credentials_env && cd /edx/app/credentials/ && ./manage.py create_or_update_site --site-id=1 --site-domain=localhost:18150 --site-name="Open edX" --platform-name="Open edX" --company-name="Open edX" --lms-url-root=http://localhost:18000 --catalog-api-url=http://b2b.devstack.discovery:18381/api/v1/ --tos-url=http://localhost:18000/tos --privacy-policy-url=http://localhost:18000/privacy --homepage-url=http://localhost:18000 --certificate-help-url=http://localhost:18000/faq --records-help-url=http://localhost:18000/faq --theme-name=openedx'
 
 ./provision-ida-user.sh ${name} ${name} ${port}
 
 # Compile static assets last since they are absolutely necessary for all services. This will allow developers to get
 # started if they do not care about static assets
 echo -e "${GREEN}Compiling static assets for ${name}...${NC}"
-docker exec -t edx.devstack.${name}  bash -c ' if ! source /edx/app/credentials/credentials_env && cd /edx/app/credentials/credentials && make static 2>creds_make_static.err; then echo "------- Last 100 lines of stderr"; tail creds_make_static.err -n 100; echo "-------"; fi;' -- "$name"
+docker exec -t b2b.devstack.${name}  bash -c ' if ! source /edx/app/credentials/credentials_env && cd /edx/app/credentials/credentials && make static 2>creds_make_static.err; then echo "------- Last 100 lines of stderr"; tail creds_make_static.err -n 100; echo "-------"; fi;' -- "$name"

--- a/provision-discovery.sh
+++ b/provision-discovery.sh
@@ -2,7 +2,7 @@
 ./provision-ida.sh discovery discovery 18381
 
 docker-compose exec discovery bash -c 'rm -rf /edx/var/discovery/*'
-docker-compose exec discovery bash -c 'source /edx/app/discovery/discovery_env && python /edx/app/discovery/discovery/manage.py create_or_update_partner --site-id 1 --site-domain localhost:18381 --code edx --name edX --courses-api-url "http://edx.devstack.lms:18000/api/courses/v1/" --ecommerce-api-url "http://edx.devstack.ecommerce:18130/api/v2/" --organizations-api-url "http://edx.devstack.lms:18000/api/organizations/v0/" --oidc-url-root "http://edx.devstack.lms:18000/oauth2" --oidc-key discovery-key --oidc-secret discovery-secret'
+docker-compose exec discovery bash -c 'source /edx/app/discovery/discovery_env && python /edx/app/discovery/discovery/manage.py create_or_update_partner --site-id 1 --site-domain localhost:18381 --code edx --name edX --courses-api-url "http://b2b.devstack.lms:18000/api/courses/v1/" --ecommerce-api-url "http://b2b.devstack.ecommerce:18130/api/v2/" --organizations-api-url "http://b2b.devstack.lms:18000/api/organizations/v0/" --oidc-url-root "http://b2b.devstack.lms:18000/oauth2" --oidc-key discovery-key --oidc-secret discovery-secret'
 docker-compose exec discovery bash -c 'source /edx/app/discovery/discovery_env && python /edx/app/discovery/discovery/manage.py refresh_course_metadata'
 docker-compose exec discovery bash -c 'source /edx/app/discovery/discovery_env && python /edx/app/discovery/discovery/manage.py update_index --disable-change-limit'
 

--- a/provision-e2e.sh
+++ b/provision-e2e.sh
@@ -10,7 +10,7 @@ elif [ ! -d "$DEVSTACK_WORKSPACE" ]; then
 fi
 
 # Copy the test course tarball into the studio container
-docker cp ${DEVSTACK_WORKSPACE}/edx-e2e-tests/upload_files/course.tar.gz edx.devstack.studio:/tmp/
+docker cp ${DEVSTACK_WORKSPACE}/edx-e2e-tests/upload_files/course.tar.gz b2b.devstack.studio:/tmp/
 
 # Extract the test course tarball
 docker-compose exec studio bash -c 'cd /tmp && tar xzf course.tar.gz'

--- a/provision-ecommerce.sh
+++ b/provision-ecommerce.sh
@@ -4,6 +4,6 @@
 ./provision-ida.sh ecommerce ecommerce 18130
 
 # Configure ecommerce
-docker exec -t edx.devstack.ecommerce bash -c 'source /edx/app/ecommerce/ecommerce_env && python /edx/app/ecommerce/ecommerce/manage.py create_or_update_site --site-id=1 --site-domain=localhost:18130 --partner-code=edX --partner-name="Open edX" --lms-url-root=http://edx.devstack.lms:18000 --client-side-payment-processor=cybersource --payment-processors=cybersource,paypal --client-id=ecommerce-key --client-secret=ecommerce-secret --from-email staff@example.com --discovery_api_url=http://edx.devstack.discovery:18381/api/v1/'
-docker exec -t edx.devstack.ecommerce bash -c 'source /edx/app/ecommerce/ecommerce_env && python /edx/app/ecommerce/ecommerce/manage.py oscar_populate_countries --initial-only'
-docker exec -t edx.devstack.ecommerce bash -c 'source /edx/app/ecommerce/ecommerce_env && python /edx/app/ecommerce/ecommerce/manage.py create_demo_data --partner=edX'
+docker exec -t b2b.devstack.ecommerce bash -c 'source /edx/app/ecommerce/ecommerce_env && python /edx/app/ecommerce/ecommerce/manage.py create_or_update_site --site-id=1 --site-domain=localhost:18130 --partner-code=edX --partner-name="Open edX" --lms-url-root=http://b2b.devstack.lms:18000 --client-side-payment-processor=cybersource --payment-processors=cybersource,paypal --client-id=ecommerce-key --client-secret=ecommerce-secret --from-email staff@example.com --discovery_api_url=http://b2b.devstack.discovery:18381/api/v1/'
+docker exec -t b2b.devstack.ecommerce bash -c 'source /edx/app/ecommerce/ecommerce_env && python /edx/app/ecommerce/ecommerce/manage.py oscar_populate_countries --initial-only'
+docker exec -t b2b.devstack.ecommerce bash -c 'source /edx/app/ecommerce/ecommerce_env && python /edx/app/ecommerce/ecommerce/manage.py create_demo_data --partner=edX'

--- a/provision-edraak-programs.sh
+++ b/provision-edraak-programs.sh
@@ -13,6 +13,7 @@ docker-compose exec edraak_programs bash -c 'python manage.py migrate --settings
 echo "** Progs: Compiling assets **"
 docker-compose exec edraak_programs bash -c 'npm rebuild node-sass'
 docker-compose exec edraak_programs bash -c 'chown -R root ~/.npm'
+docker-compose exec edraak_programs bash -c 'npm install -g'
 docker-compose exec edraak_programs bash -c 'npm install'
 docker-compose exec edraak_programs bash -c 'bower install'
 docker-compose exec edraak_programs bash -c 'gulp'

--- a/provision-edraak.sh
+++ b/provision-edraak.sh
@@ -1,13 +1,10 @@
 set -e
 
 echo "** Bringing up **"
-docker-compose $DOCKER_COMPOSE_FILES up -d mysql edraak_programs edraak_marketing
+docker-compose $DOCKER_COMPOSE_FILES up -d mysql edraak_programs
 
 echo "** Creating databases **"
-docker exec -i edx.devstack.mysql mysql -uroot mysql < provision-edraak.sql
-
-echo "** Marketing **"
-./provision-edraak-marketing.sh
+docker exec -i b2b.devstack.mysql mysql -uroot mysql < provision-edraak.sql
 
 echo "** Programs **"
 ./provision-edraak-programs.sh

--- a/provision-edraak.sql
+++ b/provision-edraak.sql
@@ -1,3 +1,2 @@
 CREATE DATABASE IF NOT EXISTS edraakprograms;
-CREATE DATABASE IF NOT EXISTS marketingsite;
 -- TODO add some edraak fixtures

--- a/provision-ida-user.sh
+++ b/provision-ida-user.sh
@@ -5,5 +5,5 @@ client_name=$2
 client_port=$3
 
 echo -e "${GREEN}Creating service user and OAuth client for ${app_name}...${NC}"
-docker exec -t edx.devstack.lms  bash -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack_docker manage_user $1_worker $1_worker@example.com --staff --superuser' -- "$app_name"
-docker exec -t edx.devstack.lms  bash -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack_docker create_oauth2_client "http://localhost:$3" "http://localhost:$3/complete/edx-oidc/" confidential --client_name $2 --client_id "$1-key" --client_secret "$1-secret" --trusted --logout_uri "http://localhost:$3/logout/" --username $1_worker' -- "$app_name" "$client_name" "$client_port"
+docker exec -t b2b.devstack.lms  bash -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack_docker manage_user $1_worker $1_worker@example.com --staff --superuser' -- "$app_name"
+docker exec -t b2b.devstack.lms  bash -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack_docker create_oauth2_client "http://localhost:$3" "http://localhost:$3/complete/edx-oidc/" confidential --client_name $2 --client_id "$1-key" --client_secret "$1-secret" --trusted --logout_uri "http://localhost:$3/logout/" --username $1_worker' -- "$app_name" "$client_name" "$client_port"

--- a/provision-ida.sh
+++ b/provision-ida.sh
@@ -5,17 +5,17 @@ client_port=$3  # The port corresponding to this IDA service in devstack.
 docker-compose $DOCKER_COMPOSE_FILES up -d $app_name
 
 echo -e "${GREEN}Installing requirements for ${app_name}...${NC}"
-docker exec -t edx.devstack.${app_name}  bash -c 'source /edx/app/$1/$1_env && cd /edx/app/$1/$1/ && make requirements' -- "$app_name"
+docker exec -t b2b.devstack.${app_name}  bash -c 'source /edx/app/$1/$1_env && cd /edx/app/$1/$1/ && make requirements' -- "$app_name"
 
 echo -e "${GREEN}Running migrations for ${app_name}...${NC}"
-docker exec -t edx.devstack.${app_name}  bash -c 'source /edx/app/$1/$1_env && cd /edx/app/$1/$1/ && make migrate' -- "$app_name"
+docker exec -t b2b.devstack.${app_name}  bash -c 'source /edx/app/$1/$1_env && cd /edx/app/$1/$1/ && make migrate' -- "$app_name"
 
 echo -e "${GREEN}Creating super-user for ${app_name}...${NC}"
-docker exec -t edx.devstack.${app_name}  bash -c 'source /edx/app/$1/$1_env && echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser(\"edx\", \"edx@example.com\", \"edx\") if not User.objects.filter(username=\"edx\").exists() else None" | python /edx/app/$1/$1/manage.py shell' -- "$app_name"
+docker exec -t b2b.devstack.${app_name}  bash -c 'source /edx/app/$1/$1_env && echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser(\"edx\", \"edx@example.com\", \"edx\") if not User.objects.filter(username=\"edx\").exists() else None" | python /edx/app/$1/$1/manage.py shell' -- "$app_name"
 
 ./provision-ida-user.sh $app_name $client_name $client_port
 
 # Compile static assets last since they are absolutely necessary for all services. This will allow developers to get
 # started if they do not care about static assets
 echo -e "${GREEN}Compiling static assets for ${app_name}...${NC}"
-docker exec -t edx.devstack.${app_name}  bash -c 'source /edx/app/$1/$1_env && cd /edx/app/$1/$1/ && make static' -- "$app_name"
+docker exec -t b2b.devstack.${app_name}  bash -c 'source /edx/app/$1/$1_env && cd /edx/app/$1/$1/ && make static' -- "$app_name"

--- a/provision-notes.sh
+++ b/provision-notes.sh
@@ -5,4 +5,4 @@
 
 # This will build the elasticsearch index for notes.
 echo -e "${GREEN}Creating indexes for edx_notes_api...${NC}"
-docker exec -t edx.devstack.edx_notes_api bash -c 'source /edx/app/$1/$1_env && cd /edx/app/$1/$1/ && python manage.py rebuild_index --noinput' -- edx_notes_api
+docker exec -t b2b.devstack.edx_notes_api bash -c 'source /edx/app/$1/$1_env && cd /edx/app/$1/$1/ && python manage.py rebuild_index --noinput' -- edx_notes_api

--- a/provision-retirement-user.sh
+++ b/provision-retirement-user.sh
@@ -4,5 +4,5 @@ app_name=$1
 user_name=$2
 
 echo -e "${GREEN}Creating retirement service user ${user_name} and DOT Application ${app_name}...${NC}"
-docker exec -t edx.devstack.lms  bash -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack_docker manage_user $1 $1@example.com --staff --superuser' -- "$user_name"
-docker exec -t edx.devstack.lms  bash -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack_docker create_dot_application $1 $2' -- "$app_name" "$user_name"
+docker exec -t b2b.devstack.lms  bash -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack_docker manage_user $1 $1@example.com --staff --superuser' -- "$user_name"
+docker exec -t b2b.devstack.lms  bash -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack_docker create_dot_application $1 $2' -- "$app_name" "$user_name"

--- a/provision-xqueue.sh
+++ b/provision-xqueue.sh
@@ -11,13 +11,13 @@ docker-compose up -d mysql
 
 # Ensure the MySQL server is online and usable
 echo "Waiting for MySQL"
-until docker exec -i edx.devstack.mysql mysql -uroot -se "SELECT EXISTS(SELECT 1 FROM mysql.user WHERE user = 'root')" &> /dev/null
+until docker exec -i b2b.devstack.mysql mysql -uroot -se "SELECT EXISTS(SELECT 1 FROM mysql.user WHERE user = 'root')" &> /dev/null
 do
   printf "."
   sleep 1
 done
 
-docker exec -i edx.devstack.mysql mysql -uroot mysql < provision-xqueue.sql
+docker exec -i b2b.devstack.mysql mysql -uroot mysql < provision-xqueue.sql
 # Run migrations
 docker-compose $DOCKER_COMPOSE_FILES exec xqueue bash -c 'source /edx/app/xqueue/xqueue_env && cd /edx/app/xqueue/xqueue && python manage.py migrate'
 # Add users that graders use to fetch data, there's one default user in Ansible which is part of our settings

--- a/provision.sh
+++ b/provision.sh
@@ -22,7 +22,7 @@ docker-compose up -d mysql mongo
 
 # Ensure the MySQL server is online and usable
 echo "Waiting for MySQL"
-until docker exec -i edx.devstack.mysql mysql -uroot -se "SELECT EXISTS(SELECT 1 FROM mysql.user WHERE user = 'root')" &> /dev/null
+until docker exec -i b2b.devstack.mysql mysql -uroot -se "SELECT EXISTS(SELECT 1 FROM mysql.user WHERE user = 'root')" &> /dev/null
 do
   printf "."
   sleep 1
@@ -35,19 +35,11 @@ sleep 20
 echo -e "MySQL ready"
 
 echo -e "${GREEN}Creating databases and users...${NC}"
-docker exec -i edx.devstack.mysql mysql -uroot mysql < provision.sql
-docker exec -i edx.devstack.mongo mongo < mongo-provision.js
+docker exec -i b2b.devstack.mysql mysql -uroot mysql < provision.sql
+docker exec -i b2b.devstack.mongo mongo < mongo-provision.js
 
-./provision-lms.sh
 
 # Nothing special needed for studio
-docker-compose $DOCKER_COMPOSE_FILES up -d studio
-#./provision-ecommerce.sh
-#./provision-discovery.sh
-#./provision-credentials.sh
-#./provision-e2e.sh
-#./provision-forum.sh
-#./provision-notes.sh
 ./provision-edraak.sh
 
 docker image prune -f

--- a/repo.sh
+++ b/repo.sh
@@ -18,32 +18,18 @@ else
 fi
 
 repos=(
-#    "https://github.com/Edraak/course-discovery.git"
-#    "https://github.com/Edraak/credentials.git"
-    "https://github.com/Edraak/cs_comments_service.git"
-#    "https://github.com/Edraak/ecommerce.git"
-#    "https://github.com/Edraak/edx-e2e-tests.git"
-#    "https://github.com/Edraak/edx-notes-api.git"
-    "https://github.com/Edraak/edraak-platform.git"
-#    "https://github.com/Edraak/xqueue.git"
-#    "https://github.com/Edraak/edx-analytics-pipeline.git"
-    "git@github.com:Edraak/marketing-site.git"
     "git@github.com:Edraak/edraak-programs.git"
-    "git@github.com:Edraak/edraak-2019-theme.git"
     "git@github.com:Edraak/shared-devstack-configs.git"
     "git@github.com:Edraak/programs-theme-white.git"
 )
 
 repo_alternative_directory=(
-	"https://github.com/Edraak/edraak-platform.git,edx-platform"
-	"git@github.com:Edraak/edraak-2019-theme.git,src/edraak-2019-theme"
   "git@github.com:Edraak/shared-devstack-configs.git,src/edxapp-envs"
   "git@github.com:Edraak/programs-theme-white.git,src/progs-theme"
 )
 
 private_repos=(
     # Needed to run whitelabel tests.
-    "https://github.com/edx/edx-themes.git"
 )
 
 name_pattern=".*Edraak/(.*).git"

--- a/repo.sh
+++ b/repo.sh
@@ -31,12 +31,14 @@ repos=(
     "git@github.com:Edraak/edraak-programs.git"
     "git@github.com:Edraak/edraak-2019-theme.git"
     "git@github.com:Edraak/shared-devstack-configs.git"
+    "git@github.com:Edraak/programs-theme-white.git"
 )
 
 repo_alternative_directory=(
 	"https://github.com/Edraak/edraak-platform.git,edx-platform"
 	"git@github.com:Edraak/edraak-2019-theme.git,src/edraak-2019-theme"
-      "git@github.com:Edraak/shared-devstack-configs.git,src/edxapp-envs"
+  "git@github.com:Edraak/shared-devstack-configs.git,src/edxapp-envs"
+  "git@github.com:Edraak/programs-theme-white.git,src/progs-theme"
 )
 
 private_repos=(


### PR DESCRIPTION
Small change to allow us to pass the path for a `.json` config file, if not passed it will fallback to `default.json` 

now to run any make command that uses `docker-compose.yml` you can do it like this to pass the path for the `.json` configs

```bash
PROGS_CFG='/app/b2b.json' make dev.nfs.up 
```

