### PR TITLE
Remove expiered edx.org ppa from devstack docker image

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -380,9 +380,9 @@ BUILD COMMANDS:
 
 .. code:: sh
 
-    git checkout master
+    git checkout edraak.keep.branch/before_python_upgrade
     git pull
-    docker build -f docker/build/edxapp/Dockerfile . -t eu.gcr.io/openedx-231314/edraak/edxapp:hawthorn.edraak.v3
+    docker build -f docker/build/edxapp/Dockerfile . -t eu.gcr.io/openedx-231314/edraak/edxapp:hawthorn.edraak.v3.2 --build-arg BASE_IMAGE_TAG=hawthorn.master --no=cache
 
 .. code:: sh
 

--- a/docker-compose-edx.yml
+++ b/docker-compose-edx.yml
@@ -31,7 +31,7 @@ services:
       EDXAPP_TEST_MONGO_HOST: edx.devstack.mongo
       NO_PYTHON_UNINSTALL: 0
       NO_PREREQ_INSTALL: 0
-    image: eu.gcr.io/openedx-231314/edraak/edxapp:hawthorn.edraak.v3
+    image: eu.gcr.io/openedx-231314/edraak/edxapp:hawthorn.edraak.v3.2
     ports:
       - "18000:18000"
       - "19876:19876" # JS test debugging
@@ -62,7 +62,7 @@ services:
       EDXAPP_TEST_MONGO_HOST: edx.devstack.mongo
       NO_PYTHON_UNINSTALL: 0
       NO_PREREQ_INSTALL: 0
-    image: eu.gcr.io/openedx-231314/edraak/edxapp:hawthorn.edraak.v3
+    image: eu.gcr.io/openedx-231314/edraak/edxapp:hawthorn.edraak.v3.2
     ports:
       - "18010:18010"
       - "19877:19877" # JS test debugging


### PR DESCRIPTION
edx.org ppa is expired and there is no plan to renew it. This PR is to resolve the issue in devstack docker image by removing apt dependency line. (the repository is not used anymore)

New image `v3.2` already pushed.

Please do **not** delete the old image from GCP

----------------
Related to https://github.com/Edraak/edx-configuration/pull/157