### PR TITLE
Remove any existing nfs docker volumes before setting it up

### DIFF
--- a/setup_native_nfs_docker_osx.sh
+++ b/setup_native_nfs_docker_osx.sh
@@ -50,7 +50,7 @@ G=`id -g`
 sudo chown -R "$U":"$G" .
 
 echo "== Removing any existing nfs volumes"
-VOLUMES=$(docker volume list | grep devstack | grep nfs | sed 's/local     //g')
+VOLUMES=$(docker volume list | sed 's/local//' | sed 's/ //g' | grep '^devstack.*nfs$')
 if [ ! -z "$VOLUMES" ]; then
   docker volume rm $VOLUMES
 fi

--- a/setup_native_nfs_docker_osx.sh
+++ b/setup_native_nfs_docker_osx.sh
@@ -49,6 +49,12 @@ U=`id -u`
 G=`id -g`
 sudo chown -R "$U":"$G" .
 
+echo "== Removing any existing nfs volumes"
+VOLUMES=$(docker volume list | grep devstack | grep nfs | sed 's/local     //g')
+if [ ! -z "$VOLUMES" ]; then
+  docker volume rm $VOLUMES
+fi
+
 echo "== Setting up nfs..."
 LINE="/Users -alldirs -mapall=$U:$G localhost"
 FILE=/etc/exports


### PR DESCRIPTION
I noticed that the script `setup_native_nfs_docker_osx.sh` sometimes fails with an error pointing out that there exist some NFS volumes already. This apparently happens when the **provision** script fails initially and needs to be re-run. This fix removes all existing NFS volumes with the name _starting with `devstack` and ending with `nfs`_.