### PR TITLE
fix progs image build

### DIFF
--- a/docker-compose-progs.yml
+++ b/docker-compose-progs.yml
@@ -13,11 +13,11 @@ version: "2.1"
 services:
 
   progs:
-    image: eu.gcr.io/openedx-231314/edraak/progs
+    image: eu.gcr.io/openedx-231314/edraak/progs:latest
     environment:
       PROGS_CFG: /app/docker.json
       NODE_ENV: development
-    command: bash -c 'while true; do python manage.py runserver 0.0.0.0:8800 --settings=edraakprograms.dev; sleep 2; done'
+    command: bash -c 'while true; do python3.8 manage.py runserver 0.0.0.0:8800 --settings=edraakprograms.dev; sleep 2; done'
     container_name: edraak.devstack.programs
     working_dir: /app
     ports:


### PR DESCRIPTION
running new docker image builds fail after upgrading python. 
Resolution:

> hardcode usage of python3.8 and pip3.8 in progs compose file