### PR TITLE
Upgrade mongo to 4.4.14 to match staging and production

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     # We disable the journal for a minor performance gain.
     command: mongod --nojournal
     container_name: edx.devstack.mongo
-    image: mongo:4.2.17
+    image: mongo:4.4.14
     ports:
       - "27017:27017"
     volumes:


### PR DESCRIPTION
# IMPORTANT
Steps for upgrade:
1. Run the following command in your mongo shell:
```
db.adminCommand( { setFeatureCompatibilityVersion: "4.2" } )
```
2. Run `make down` on your devstack.
3. Run `make dev.up` on your devstack.